### PR TITLE
Add linting tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN set -eux; \
     vim
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip install ruff==0.5.5
+
 RUN set -eux; \
     git clone https://github.com/timescale/pgspot.git /build/pgspot; \
     pip install /build/pgspot; \

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,21 @@ build-sql:
 test:
 	@./build.py test
 
-.PHONY: pgspot
-pgspot:
-	@./build.py pgspot
+.PHONY: lint-sql
+lint-sql:
+	@./build.py lint-sql
+
+.PHONY: lint-py
+lint-py:
+	@./build.py lint-py
+
+.PHONY: lint
+lint:
+	@./build.py lint
+
+.PHONY: format-py
+format-py:
+	@./build.py format-py
 
 .PHONY: docker-build
 docker-build:

--- a/src/ai/anthropic.py
+++ b/src/ai/anthropic.py
@@ -3,20 +3,27 @@ from anthropic import Anthropic
 
 
 def find_api_key(plpy) -> str:
-    r = plpy.execute("select pg_catalog.current_setting('ai.anthropic_api_key', true) as api_key")
+    r = plpy.execute(
+        "select pg_catalog.current_setting('ai.anthropic_api_key', true) as api_key"
+    )
     if len(r) >= 0:
         return r[0]["api_key"]
     else:
         plpy.error("missing api key")
 
 
-def make_client(plpy, api_key: Optional[str] = None, base_url: Optional[str] = None, timeout: Optional[float] = None,
-                max_retries: Optional[int] = None) -> Anthropic:
+def make_client(
+    plpy,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    timeout: Optional[float] = None,
+    max_retries: Optional[int] = None,
+) -> Anthropic:
     if api_key is None:
         api_key = find_api_key(plpy)
     args = {}
     if timeout is not None:
-        args['timeout'] = timeout
+        args["timeout"] = timeout
     if max_retries is not None:
-        args['max_retries'] = max_retries
+        args["max_retries"] = max_retries
     return Anthropic(api_key=api_key, base_url=base_url, **args)

--- a/src/ai/cohere.py
+++ b/src/ai/cohere.py
@@ -3,7 +3,9 @@ from cohere import Client
 
 
 def find_api_key(plpy) -> str:
-    r = plpy.execute("select pg_catalog.current_setting('ai.cohere_api_key', true) as api_key")
+    r = plpy.execute(
+        "select pg_catalog.current_setting('ai.cohere_api_key', true) as api_key"
+    )
     if len(r) >= 0:
         return r[0]["api_key"]
     else:

--- a/src/ai/ollama.py
+++ b/src/ai/ollama.py
@@ -3,7 +3,9 @@ from ollama import Client
 
 
 def get_ollama_host(plpy) -> str:
-    r = plpy.execute("select pg_catalog.current_setting('ai.ollama_host', true) as ollama_host")
+    r = plpy.execute(
+        "select pg_catalog.current_setting('ai.ollama_host', true) as ollama_host"
+    )
     if len(r) >= 0:
         return r[0]["ollama_host"]
     else:

--- a/src/ai/openai.py
+++ b/src/ai/openai.py
@@ -4,7 +4,9 @@ from typing import Optional, Generator, Union
 
 
 def get_openai_api_key(plpy) -> str:
-    r = plpy.execute("select pg_catalog.current_setting('ai.openai_api_key', true) as api_key")
+    r = plpy.execute(
+        "select pg_catalog.current_setting('ai.openai_api_key', true) as api_key"
+    )
     if len(r) >= 0:
         return r[0]["api_key"]
     else:
@@ -17,17 +19,25 @@ def make_client(plpy, api_key: Optional[str] = None) -> openai.Client:
     return openai.Client(api_key=api_key)
 
 
-def list_models(plpy, api_key: Optional[str] = None) -> Generator[tuple[str, datetime, str], None, None]:
+def list_models(
+    plpy, api_key: Optional[str] = None
+) -> Generator[tuple[str, datetime, str], None, None]:
     client = make_client(plpy, api_key)
     from datetime import datetime, timezone
+
     for model in client.models.list():
         created = datetime.fromtimestamp(model.created, timezone.utc)
         yield model.id, created, model.owned_by
 
 
-def embed(plpy, model: str, input: Union[str, list[str], list[int]], api_key: Optional[str] = None,
-          dimensions: Optional[int] = None,
-          user: Optional[str] = None) -> Generator[tuple[int, list[float]], None, None]:
+def embed(
+    plpy,
+    model: str,
+    input: Union[str, list[str], list[int]],
+    api_key: Optional[str] = None,
+    dimensions: Optional[int] = None,
+    user: Optional[str] = None,
+) -> Generator[tuple[int, list[float]], None, None]:
     client = make_client(plpy, api_key)
     args = {}
     if dimensions is not None:

--- a/src/ruff.toml
+++ b/src/ruff.toml
@@ -1,0 +1,61 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"


### PR DESCRIPTION
Adds 4 new make targets:

1. lint-sql - runs pgspot linter against the output SQL for the current version
2. lint-py - runs ruff linter against the python source files
3. lint - runs both lint-sql and lint-py
4. format-py - runs ruff format check against the python source files

Fixes issues found by linters and format check