### PR TITLE
OpenAI base_url parameter and Ollama OpenAI support

### DIFF
--- a/sql/idempotent/01-openai.sql
+++ b/sql/idempotent/01-openai.sql
@@ -35,7 +35,7 @@ set search_path to pg_catalog, pg_temp
 -- openai_list_models
 -- list models supported on the openai platform
 -- https://platform.openai.com/docs/api-reference/models/list
-create or replace function ai.openai_list_models(_api_key text default null)
+create or replace function ai.openai_list_models(_api_key text default null, _base_url text default null)
 returns table
 ( id text
 , created timestamptz
@@ -44,7 +44,7 @@ returns table
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    for tup in ai.openai.list_models(plpy, _api_key):
+    for tup in ai.openai.list_models(plpy, _api_key, _base_url):
         yield tup
 $python$
 language plpython3u volatile parallel safe security invoker
@@ -59,13 +59,14 @@ create or replace function ai.openai_embed
 ( _model text
 , _input text
 , _api_key text default null
+, _base_url text default null
 , _dimensions int default null
 , _user text default null
 ) returns @extschema:vector@.vector
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, dimensions=_dimensions, user=_user):
+    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         return tup[1]
 $python$
 language plpython3u volatile parallel safe security invoker
@@ -80,6 +81,7 @@ create or replace function ai.openai_embed
 ( _model text
 , _input text[]
 , _api_key text default null
+, _base_url text default null
 , _dimensions int default null
 , _user text default null
 ) returns table
@@ -89,7 +91,7 @@ create or replace function ai.openai_embed
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, dimensions=_dimensions, user=_user):
+    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         yield tup
 $python$
 language plpython3u volatile parallel safe security invoker
@@ -104,13 +106,14 @@ create or replace function ai.openai_embed
 ( _model text
 , _input int[]
 , _api_key text default null
+, _base_url text default null
 , _dimensions int default null
 , _user text default null
 ) returns @extschema:vector@.vector
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, dimensions=_dimensions, user=_user):
+    for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         return tup[1]
 $python$
 language plpython3u volatile parallel safe security invoker
@@ -125,6 +128,7 @@ create or replace function ai.openai_chat_complete
 ( _model text
 , _messages jsonb
 , _api_key text default null
+, _base_url text default null
 , _frequency_penalty float8 default null
 , _logit_bias jsonb default null
 , _logprobs boolean default null
@@ -144,7 +148,7 @@ create or replace function ai.openai_chat_complete
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    client = ai.openai.make_client(plpy, _api_key)
+    client = ai.openai.make_client(plpy, _api_key, _base_url)
     import json
 
     _messages_1 = json.loads(_messages)
@@ -202,11 +206,12 @@ create or replace function ai.openai_moderate
 ( _model text
 , _input text
 , _api_key text default null
+, _base_url text default null
 ) returns jsonb
 as $python$
     #ADD-PYTHON-LIB-DIR
     import ai.openai
-    client = ai.openai.make_client(plpy, _api_key)
+    client = ai.openai.make_client(plpy, _api_key, _base_url)
     moderation = client.moderations.create(input=_input, model=_model)
     return moderation.model_dump_json()
 $python$

--- a/src/ai/anthropic.py
+++ b/src/ai/anthropic.py
@@ -6,10 +6,9 @@ def find_api_key(plpy) -> str:
     r = plpy.execute(
         "select pg_catalog.current_setting('ai.anthropic_api_key', true) as api_key"
     )
-    if len(r) >= 0:
-        return r[0]["api_key"]
-    else:
+    if len(r) == 0:
         plpy.error("missing api key")
+    return r[0]["api_key"]
 
 
 def make_client(

--- a/src/ai/cohere.py
+++ b/src/ai/cohere.py
@@ -6,10 +6,9 @@ def find_api_key(plpy) -> str:
     r = plpy.execute(
         "select pg_catalog.current_setting('ai.cohere_api_key', true) as api_key"
     )
-    if len(r) >= 0:
-        return r[0]["api_key"]
-    else:
+    if len(r) == 0:
         plpy.error("missing api key")
+    return r[0]["api_key"]
 
 
 def make_client(plpy, api_key: Optional[str]) -> Client:

--- a/src/ai/ollama.py
+++ b/src/ai/ollama.py
@@ -6,12 +6,11 @@ def get_ollama_host(plpy) -> str:
     r = plpy.execute(
         "select pg_catalog.current_setting('ai.ollama_host', true) as ollama_host"
     )
-    if len(r) >= 0:
-        return r[0]["ollama_host"]
-    else:
+    if len(r) == 0:
         host = "http://localhost:11434"
         plpy.warning(f"defaulting Ollama host to: {host}")
         return host
+    return r[0]["ollama_host"]
 
 
 def make_client(plpy, host: Optional[str] = None) -> Client:

--- a/src/ai/openai.py
+++ b/src/ai/openai.py
@@ -7,10 +7,9 @@ def get_openai_api_key(plpy) -> str:
     r = plpy.execute(
         "select pg_catalog.current_setting('ai.openai_api_key', true) as api_key"
     )
-    if len(r) >= 0:
-        return r[0]["api_key"]
-    else:
+    if len(r) == 0:
         plpy.error("missing api key")
+    return r[0]["api_key"]
 
 
 def make_client(plpy, api_key: Optional[str] = None) -> openai.Client:

--- a/tests/ollama.sql
+++ b/tests/ollama.sql
@@ -26,6 +26,7 @@ values
 , ('ollama_list_models-no-host')
 , ('ollama_embed')
 , ('ollama_embed-no-host')
+, ('ollama_embed_via_openai')
 , ('ollama_generate')
 , ('ollama_generate-no-host')
 , ('ollama_generate-image')
@@ -94,6 +95,27 @@ select vector_dims
     , 'the purple elephant sits on a red mushroom'
     )
 ) as actual
+\gset
+
+\ir eval.sql
+
+
+-------------------------------------------------------------------------------
+-- ollama_embed_via_openai
+\set testname ollama_embed_via_openai
+\set expected 4096
+\echo :testname
+
+select vector_dims
+(
+    ai.openai_embed
+    ( 'llama3'
+    , 'the purple elephant sits on a red mushroom'
+    , _api_key=>'this is a garbage api key'
+    , _base_url=>concat($1::text, '/v1/')
+    )
+) as actual
+\bind :ollama_host
 \gset
 
 \ir eval.sql


### PR DESCRIPTION
@avthars not sure whether we want to support this or not.

It would allow someone to use the `openai` functions but point it to [openrouter](https://openrouter.ai/docs/quick-start) or [ollama](https://github.com/ollama/ollama/blob/main/docs/openai.md) instead of openai.

There are actually a number of parameters to creating an openai client that we don't currently support that we may want to consider:

```python
    def __init__(
        self,
        *,
        api_key: str | None = None,
        organization: str | None = None,
        project: str | None = None,
        base_url: str | httpx.URL | None = None,
        timeout: Union[float, Timeout, None, NotGiven] = NOT_GIVEN,
        max_retries: int = DEFAULT_MAX_RETRIES,
        default_headers: Mapping[str, str] | None = None,
        default_query: Mapping[str, object] | None = None,
        # Configure a custom httpx client.
        # We provide a `DefaultHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
        # See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
        http_client: httpx.Client | None = None,
        # Enable or disable schema validation for data returned by the API.
        # When enabled an error APIResponseValidationError is raised
        # if the API responds with invalid data for the expected schema.
        #
        # This parameter may be removed or changed in the future.
        # If you rely on this feature, please open a GitHub issue
        # outlining your use-case to help us decide if it should be
        # part of our public interface in the future.
        _strict_response_validation: bool = False,
    ) -> None:
```

Fixes #33 