### PR TITLE
Fix typo referencing OpenAI instead of Ollama

### DIFF
--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -43,7 +43,7 @@ running pgai, the ollama host address is `http://host.docker.internal:11434`.
 
 This section shows you how to use AI directly from your database using SQL.
 
-- [List_models](#list-models): list the models supported by OpenAI functions in pgai.
+- [List_models](#list-models): list the models supported by Ollama functions in pgai.
 - [Embed](#embed): generate [embeddings](https://platform.openai.com/docs/guides/embeddings) using a
   specified model.
 - [Chat_complete](#chat-complete): generate text or complete a chat.


### PR DESCRIPTION
- Fix typo referencing OpenAI instead of Ollama