### PR TITLE
Modify func volatility for performance

### DIFF
--- a/sql/idempotent/01-openai.sql
+++ b/sql/idempotent/01-openai.sql
@@ -11,7 +11,7 @@ as $python$
     tokens = encoding.encode(_text)
     return tokens
 $python$
-language plpython3u strict volatile parallel safe security invoker
+language plpython3u strict immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -27,7 +27,7 @@ as $python$
     content = encoding.decode(_tokens)
     return content
 $python$
-language plpython3u strict volatile parallel safe security invoker
+language plpython3u strict immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -69,7 +69,7 @@ as $python$
     for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         return tup[1]
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -94,7 +94,7 @@ as $python$
     for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         yield tup
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -116,7 +116,7 @@ as $python$
     for tup in ai.openai.embed(plpy, _model, _input, api_key=_api_key, base_url=_base_url, dimensions=_dimensions, user=_user):
         return tup[1]
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -215,6 +215,6 @@ as $python$
     moderation = client.moderations.create(input=_input, model=_model)
     return moderation.model_dump_json()
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;

--- a/sql/idempotent/02-ollama.sql
+++ b/sql/idempotent/02-ollama.sql
@@ -113,7 +113,7 @@ as $python$
     resp = client.embeddings(_model, _input, options=_options, keep_alive=_keep_alive)
     return resp.get("embedding")
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 

--- a/sql/idempotent/04-cohere.sql
+++ b/sql/idempotent/04-cohere.sql
@@ -50,7 +50,7 @@ as $python$
     response = client.tokenize(text=_text, model=_model)
     return response.tokens
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -66,7 +66,7 @@ as $python$
     response = client.detokenize(tokens=_tokens, model=_model)
     return response.text
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -93,7 +93,7 @@ as $python$
     response = client.embed(texts=[_input], model=_model, **args)
     return response.embeddings[0]
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -122,7 +122,7 @@ as $python$
     response = client.classify(inputs=_inputs, model=_model, **args)
     return response.json()
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -152,9 +152,9 @@ as $python$
         args["truncate"] = _truncate
     response = client.classify(inputs=_inputs, model=_model, **args)
     for x in response.classifications:
-        yield (x.input, x.prediction, x.confidence)
+        yield x.input, x.prediction, x.confidence
 $python$
-language plpython3u volatile parallel safe security invoker
+language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -188,7 +188,7 @@ as $python$
     _documents_1 = json.loads(_documents)
     response = client.rerank(model=_model, query=_query, documents=_documents_1, **args)
     return response.json()
-$python$ language plpython3u volatile parallel safe security invoker
+$python$ language plpython3u immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
@@ -221,7 +221,7 @@ from pg_catalog.jsonb_to_recordset
     , _max_chunks_per_doc=>_max_chunks_per_doc
     ) operator(pg_catalog.->) 'results'
 ) x("index" int, "document" jsonb, relevance_score float8)
-$func$ language sql volatile parallel safe security invoker
+$func$ language sql immutable parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 


### PR DESCRIPTION
Database functions were all volatile. This is not as performant as it could be. This PR changes the volatility of many functions to address this.

- The text generation/chat complete functions were left volatile
- ollama_ps was left volatile since it describes the running state of ollama
- the "list models" were made stable since models can be added/removed at any time
- embed, classify, moderate, etc. were made immutable