### PR TITLE
Add openai_chat_complete_simple (and tests)

### DIFF
--- a/sql/ai--0.4.0.sql
+++ b/sql/ai--0.4.0.sql
@@ -400,6 +400,26 @@ language plpython3u volatile parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
+------------------------------------------------------------------------------------
+-- openai_chat_complete_simple
+-- simple chat completion that only requires a message and only returns the response
+create or replace function ai.openai_chat_complete_simple
+( _message text
+, _api_key text default null
+) returns text
+as $$
+declare
+    model text := 'gpt-4o';
+    messages jsonb;
+begin
+    messages := jsonb_build_array(
+        jsonb_build_object('role', 'system', 'content', 'you are a helpful assistant'),
+        jsonb_build_object('role', 'user', 'content', _message)
+    );
+    return ai.openai_chat_complete(model, messages, _api_key)->'choices'->0->'message'->>'content';
+end;
+$$ language plpgsql;
+
 -------------------------------------------------------------------------------
 -- openai_moderate
 -- classify text as potentially harmful or not

--- a/sql/idempotent/001-openai.sql
+++ b/sql/idempotent/001-openai.sql
@@ -198,6 +198,26 @@ language plpython3u volatile parallel safe security invoker
 set search_path to pg_catalog, pg_temp
 ;
 
+------------------------------------------------------------------------------------
+-- openai_chat_complete_simple
+-- simple chat completion that only requires a message and only returns the response
+create or replace function ai.openai_chat_complete_simple
+( _message text
+, _api_key text default null
+) returns text
+as $$
+declare
+    model text := 'gpt-4o';
+    messages jsonb;
+begin
+    messages := jsonb_build_array(
+        jsonb_build_object('role', 'system', 'content', 'you are a helpful assistant'),
+        jsonb_build_object('role', 'user', 'content', _message)
+    );
+    return ai.openai_chat_complete(model, messages, _api_key)->'choices'->0->'message'->>'content';
+end;
+$$ language plpgsql;
+
 -------------------------------------------------------------------------------
 -- openai_moderate
 -- classify text as potentially harmful or not

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -256,6 +256,35 @@ def test_openai_chat_complete_no_key(cur_with_api_key):
     assert actual is True
 
 
+def test_openai_chat_complete_simple(cur, openai_api_key):
+    cur.execute(
+        """
+        with x as
+        (
+            select ai.openai_chat_complete_simple('what is the typical weather like in Alabama in June', _api_key=>%s) as actual
+        )
+        select x.actual is not null
+        from x
+    """,
+        (openai_api_key,),
+    )
+    actual = cur.fetchone()[0]
+    assert actual is True
+
+
+def test_openai_chat_complete_simple_no_key(cur_with_api_key):
+    cur_with_api_key.execute("""
+        with x as
+        (
+            select ai.openai_chat_complete_simple('what is the typical weather like in Alabama in June') as actual
+        )
+        select x.actual is not null
+        from x
+    """)
+    actual = cur_with_api_key.fetchone()[0]
+    assert actual is True
+
+
 def test_openai_moderate(cur, openai_api_key):
     cur.execute(
         """


### PR DESCRIPTION
Current openai_chat_complete function requires choosing the model, submitting the message in a json object, and parsing the json object output. This can feel cumbersome to do.

This openai_chat_complete_simple chooses a default model, only requires the message to be passed as text, and returns the response as text. This should be easier to use, albeit maybe not as powerful.

Future work:

- Consider making the default model an env variable

- Repeat for the other LLMs (Anthropic, Cohere, Ollama)