### PR TITLE
Add ts-vector team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @jgpruitt @cevian @avthars
+* @jgpruitt @cevian @avthars @timescale/ts-vector
 /.github/ @jgpruitt @cevian @avthars


### PR DESCRIPTION
Just include the entire ts-vector team there.