### PR TITLE
Add docker image for vectorizer tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ build-sql:
 test-server:
 	@./build.py test-server
 
+.PHONY: vectorizer
+vectorizer:
+	@./build.py vectorizer
+
 .PHONY: test
 test:
 	@./build.py test
@@ -102,17 +106,33 @@ format-py:
 docker-build:
 	@PG_MAJOR=$(PG_MAJOR) ./build.py docker-build
 
+.PHONY: docker-build-vectorizer
+docker-build-vectorizer:
+	@./build.py docker-build-vectorizer
+
 .PHONY: docker-run
 docker-run:
 	@./build.py docker-run
+
+.PHONY: docker-run-vectorizer
+docker-run-vectorizer:
+	@./build.py docker-run-vectorizer
 
 .PHONY: docker-stop
 docker-stop:
 	@./build.py docker-stop
 
+.PHONY: docker-stop-vectorizer
+docker-stop-vectorizer:
+	@./build.py docker-stop-vectorizer
+
 .PHONY: docker-rm
 docker-rm:
 	@./build.py docker-rm
+
+.PHONY: docker-rm-vectorizer
+docker-rm-vectorizer:
+	@./build.py docker-rm-vectorizer
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ default: help
 .PHONY: help
 help:
 	@./build.py help
-	@echo "- docker-shell      launches a bash shell in the container"
-	@echo "- docker-psql       launches a psql shell in the container"
+	@echo "- docker-shell     launches a bash shell in the container"
+	@echo "- docker-psql      launches a psql shell in the container"
 
 .PHONY: clean
 clean:
@@ -22,9 +22,9 @@ clean-sql:
 clean-py:
 	@./build.py clean-py
 
-.PHONY: clean-vectorizer
-clean-vectorizer:
-	@./build.py clean-vectorizer
+.PHONY: clean-vec
+clean-vec:
+	@./build.py clean-vec
 
 .PHONY: build
 build:
@@ -50,9 +50,9 @@ install-prior-py:
 install-py:
 	@./build.py install-py
 
-.PHONY: install-vectorizer
-install-vectorizer:
-	@./build.py install-vectorizer
+.PHONY: install-vec
+install-vec:
+	@./build.py install-vec
 
 .PHONY: uninstall
 uninstall:
@@ -66,9 +66,9 @@ uninstall-sql:
 uninstall-py:
 	@./build.py uninstall-py
 
-.PHONY: uninstall-vectorizer
-uninstall-vectorizer:
-	@./build.py uninstall-vectorizer
+.PHONY: uninstall-vec
+uninstall-vec:
+	@./build.py uninstall-vec
 
 .PHONY: build-sql
 build-sql:
@@ -106,33 +106,33 @@ format-py:
 docker-build:
 	@PG_MAJOR=$(PG_MAJOR) ./build.py docker-build
 
-.PHONY: docker-build-vectorizer
-docker-build-vectorizer:
-	@./build.py docker-build-vectorizer
+.PHONY: docker-build-vec
+docker-build-vec:
+	@./build.py docker-build-vec
 
 .PHONY: docker-run
 docker-run:
 	@./build.py docker-run
 
-.PHONY: docker-run-vectorizer
-docker-run-vectorizer:
-	@./build.py docker-run-vectorizer
+.PHONY: docker-run-vec
+docker-run-vec:
+	@./build.py docker-run-vec
 
 .PHONY: docker-stop
 docker-stop:
 	@./build.py docker-stop
 
-.PHONY: docker-stop-vectorizer
-docker-stop-vectorizer:
-	@./build.py docker-stop-vectorizer
+.PHONY: docker-stop-vec
+docker-stop-vec:
+	@./build.py docker-stop-vec
 
 .PHONY: docker-rm
 docker-rm:
 	@./build.py docker-rm
 
-.PHONY: docker-rm-vectorizer
-docker-rm-vectorizer:
-	@./build.py docker-rm-vectorizer
+.PHONY: docker-rm-vec
+docker-rm-vec:
+	@./build.py docker-rm-vec
 
 .PHONY: run
 run:

--- a/build.py
+++ b/build.py
@@ -7,31 +7,39 @@ import tempfile
 from pathlib import Path
 
 HELP = """Available targets:
-- help              displays this message and exits
-- install           installs the project
-- uninstall         uninstalls the project
-- clean             removes build artifacts from the project directories
-- build             alias for build-sql
-- build-sql         constructs the sql files for the extension
-- build-install     runs build followed by install
-- clean-sql         removes sql file artifacts from the project directories
-- install-sql       installs the sql files into the postgres installation
-- uninstall-sql     removes the sql extension from the postgres installation
-- install-prior-py  installs the python package and dependencies from previously released versions
-- install-py        installs the python package and dependencies for the current version
-- clean-py          removes python build artifacts from the project directories
-- uninstall-py      removes the python package and dependencies from the system
-- test              runs the unit tests against the docker database
-- test-server       runs the test http server in the docker container
-- lint-sql          runs pgspot against the `ai--<this_version>.sql` file
-- lint-py           runs ruff linter against the python source files
-- lint              runs both sql and python linters
-- format-py         runs ruff to check formatting of the python source files
-- docker-build      builds the development docker image
-- docker-run        launches a container in docker using the docker image
-- docker-stop       stops the container
-- docker-rm         deletes the development container
-- run               builds+runs the development container and installs the extension"""
+- help             displays this message and exits
+- build-install    runs build followed by install
+- install          installs the project
+- install-sql      installs the sql files into the postgres installation
+- install-prior-py installs the extension's python package for prior versions
+- install-py       installs the extension's python package
+- install-vec      installs the vectorizer python tool
+- uninstall        uninstalls the project
+- uninstall-sql    removes the sql extension from the postgres installation
+- uninstall-py     removes the extension's python package from the system
+- uninstall-vec    removes the vectorizer python tool from the system
+- build            alias for build-sql
+- build-sql        constructs the sql files for the extension
+- clean            removes python build artifacts from the src dir
+- clean-sql        removes sql file artifacts from the sql dir
+- clean-py         removes python build artifacts from the extension src dir
+- clean-vec        removes python build artifacts from the vectorizer src dir
+- test             runs the tests in the docker container
+- test-server      runs the test http server in the docker container
+- vectorizer       runs the vectorizer python tool in the docker container
+- lint-sql         runs pgspot against the `ai--<this_version>.sql` file
+- lint-py          runs ruff linter against the python source files
+- lint             runs both sql and python linters
+- format-py        runs ruff to check formatting of the python source files
+- docker-build     builds the dev docker image
+- docker-run       launches a container in docker using the docker image
+- docker-stop      stops the container
+- docker-rm        deletes the dev container
+- docker-build-vec builds the docker image for the vectorizer tool
+- docker-run-vec   runs a docker container for the vectorizer tool
+- docker-stop-vec  stops the docker container for the vectorizer tool
+- docker-rm-vec    deletes the docker container for the vectorizer tool
+- run              builds+runs the dev container and installs the extension"""
 
 
 def versions() -> list[str]:
@@ -649,7 +657,7 @@ if __name__ == "__main__":
             install_prior_py()
         elif action == "install-py":
             install_py()
-        elif action == "install-vectorizer":
+        elif action == "install-vec":
             install_vectorizer()
         elif action == "install-sql":
             install_sql()
@@ -659,13 +667,13 @@ if __name__ == "__main__":
             clean_sql()
         elif action == "clean-py":
             clean_py()
-        elif action == "clean-vectorizer":
+        elif action == "clean-vec":
             clean_vectorizer()
         elif action == "clean":
             clean()
         elif action == "uninstall-py":
             uninstall_py()
-        elif action == "uninstall-vectorizer":
+        elif action == "uninstall-vec":
             uninstall_vectorizer()
         elif action == "uninstall-sql":
             uninstall_sql()
@@ -687,19 +695,19 @@ if __name__ == "__main__":
             format_py()
         elif action == "docker-build":
             docker_build()
-        elif action == "docker-build-vectorizer":
+        elif action == "docker-build-vec":
             docker_build_vectorizer()
         elif action == "docker-run":
             docker_run()
-        elif action == "docker-run-vectorizer":
+        elif action == "docker-run-vec":
             docker_run_vectorizer()
         elif action == "docker-stop":
             docker_stop()
-        elif action == "docker-stop-vectorizer":
+        elif action == "docker-stop-vec":
             docker_stop_vectorizer()
         elif action == "docker-rm":
             docker_rm()
-        elif action == "docker-rm-vectorizer":
+        elif action == "docker-rm-vec":
             docker_rm_vectorizer()
         elif action == "run":
             run()

--- a/build.py
+++ b/build.py
@@ -501,6 +501,21 @@ def test_server() -> None:
         )
 
 
+def vectorizer() -> None:
+    if where_am_i() == "host":
+        cmd = "docker exec -it pgai vectorizer --version"
+        subprocess.run(cmd, shell=True, check=True, env=os.environ, cwd=project_dir())
+    else:
+        cmd = "vectorizer --version"
+        subprocess.run(
+            cmd,
+            shell=True,
+            check=True,
+            env=os.environ,
+            cwd=project_dir(),
+        )
+
+
 def test() -> None:
     subprocess.run("pytest", shell=True, check=True, env=os.environ, cwd=tests_dir())
 
@@ -533,13 +548,24 @@ def format_py() -> None:
 
 
 def docker_build() -> None:
-    assert Path.cwd() == project_dir()
     subprocess.run(
         f"""docker build --build-arg PG_MAJOR={pg_major()} -t pgai .""",
         shell=True,
         check=True,
         env=os.environ,
         text=True,
+        cwd=project_dir(),
+    )
+
+
+def docker_build_vectorizer() -> None:
+    subprocess.run(
+        f"""docker build -t pgai/vectorizer:latest -t pgai/vectorizer:{this_version()} .""",
+        shell=True,
+        check=True,
+        env=os.environ,
+        text=True,
+        cwd=src_vectorizer_dir(),
     )
 
 
@@ -556,15 +582,40 @@ def docker_run() -> None:
     subprocess.run(cmd, shell=True, check=True, env=os.environ, text=True)
 
 
+def docker_run_vectorizer() -> None:
+    cmd = " ".join(
+        [
+            f"docker run -d --name vectorizer pgai/vectorizer:{this_version()}",
+        ]
+    )
+    subprocess.run(cmd, shell=True, check=True, env=os.environ, text=True)
+
+
 def docker_stop() -> None:
     subprocess.run(
         """docker stop pgai""", shell=True, check=True, env=os.environ, text=True
     )
 
 
+def docker_stop_vectorizer() -> None:
+    subprocess.run(
+        """docker stop vectorizer""", shell=True, check=True, env=os.environ, text=True
+    )
+
+
 def docker_rm() -> None:
     subprocess.run(
         """docker rm --force --volumes pgai""",
+        shell=True,
+        check=True,
+        env=os.environ,
+        text=True,
+    )
+
+
+def docker_rm_vectorizer() -> None:
+    subprocess.run(
+        """docker rm --force --volumes vectorizer""",
         shell=True,
         check=True,
         env=os.environ,
@@ -622,6 +673,8 @@ if __name__ == "__main__":
             uninstall()
         elif action == "test-server":
             test_server()
+        elif action == "vectorizer":
+            vectorizer()
         elif action == "test":
             test()
         elif action == "lint-sql":
@@ -634,12 +687,20 @@ if __name__ == "__main__":
             format_py()
         elif action == "docker-build":
             docker_build()
+        elif action == "docker-build-vectorizer":
+            docker_build_vectorizer()
         elif action == "docker-run":
             docker_run()
+        elif action == "docker-run-vectorizer":
+            docker_run_vectorizer()
         elif action == "docker-stop":
             docker_stop()
+        elif action == "docker-stop-vectorizer":
+            docker_stop_vectorizer()
         elif action == "docker-rm":
             docker_rm()
+        elif action == "docker-rm-vectorizer":
+            docker_rm_vectorizer()
         elif action == "run":
             run()
         else:

--- a/src/vectorizer/.dockerignore
+++ b/src/vectorizer/.dockerignore
@@ -1,0 +1,3 @@
+build
+vectorizer.egg-info
+Dockerfile

--- a/src/vectorizer/Dockerfile
+++ b/src/vectorizer/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /build
+COPY ./ /build/
+RUN pip3 install -v --compile --root-user-action=ignore /build
+WORKDIR /
+RUN rm -r /build
+
+ENV PATH=/usr/local/bin/:$PATH
+ENTRYPOINT [ "vectorizer" ]
+CMD ["--version"]


### PR DESCRIPTION
The vectorizer tool can be run in the development container for ease of development and testing. However, we want a separate Docker image for production deployments. This PR adds the image for prod and make targets to aid in all the various build/test tasks.