### PR TITLE
build fixes

### DIFF
--- a/build.py
+++ b/build.py
@@ -480,7 +480,7 @@ def install() -> None:
     install_prior_py()
     install_py()
     install_sql()
-    install_vectorizer()
+    # installing the vectorizer cli tool should be explicit
 
 
 def build_install() -> None:

--- a/src/extension/setup.cfg
+++ b/src/extension/setup.cfg
@@ -5,4 +5,11 @@ version = attr: ai.__version__
 [options]
 python_requires = >=3.10
 packages = ai
-install_requires = file: requirements.txt
+# unfortunately, we cannot refer to the requirements.txt file with python 3.10
+install_requires =
+    openai==1.44.0
+    tiktoken==0.7.0
+    ollama==0.2.1
+    anthropic==0.29.0
+    cohere==5.5.8
+    backoff==2.2.1


### PR DESCRIPTION
1. don't install the vectorizer cli tool by default. make it explicit
2. fix setup.cfg so that it's compatible with python 3.10