### PR TITLE
feat: make certain tests run by default

### DIFF
--- a/tests/contents/test_contents.py
+++ b/tests/contents/test_contents.py
@@ -7,7 +7,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_contents_tests = os.getenv("ENABLE_CONTENTS_TESTS")
-if not enable_contents_tests or enable_contents_tests == "0":
+if enable_contents_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/dump_restore/test_dump_restore.py
+++ b/tests/dump_restore/test_dump_restore.py
@@ -7,7 +7,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_dump_restore_tests = os.getenv("ENABLE_DUMP_RESTORE_TESTS")
-if not enable_dump_restore_tests or enable_dump_restore_tests == "0":
+if enable_dump_restore_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/privileges/test_privileges.py
+++ b/tests/privileges/test_privileges.py
@@ -6,7 +6,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_privileges_tests = os.getenv("ENABLE_PRIVILEGES_TESTS")
-if not enable_privileges_tests or enable_privileges_tests == "0":
+if enable_privileges_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_chunking.py
+++ b/tests/vectorizer/test_chunking.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_embedding.py
+++ b/tests/vectorizer/test_embedding.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_formatting.py
+++ b/tests/vectorizer/test_formatting.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_indexing.py
+++ b/tests/vectorizer/test_indexing.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_processing.py
+++ b/tests/vectorizer/test_processing.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_scheduling.py
+++ b/tests/vectorizer/test_scheduling.py
@@ -5,7 +5,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/vectorizer/test_vectorizer.py
+++ b/tests/vectorizer/test_vectorizer.py
@@ -8,7 +8,7 @@ import pytest
 
 # skip tests in this module if disabled
 enable_vectorizer_tests = os.getenv("ENABLE_VECTORIZER_TESTS")
-if not enable_vectorizer_tests or enable_vectorizer_tests == "0":
+if enable_vectorizer_tests == "0":
     pytest.skip(allow_module_level=True)
 
 


### PR DESCRIPTION
i want these tests to run by default unless explicitly disabled. mainly for ci, but I guess it doesn't hurt in general.
these tests do not require any API keys, so they are easy to run by default
when we integrate Alejandro's hoverfly stuff, we can default enable all of them