### PR TITLE
feat: if scheduling is none, indexing must be none

### DIFF
--- a/projects/extension/sql/ai--0.4.0.sql
+++ b/projects/extension/sql/ai--0.4.0.sql
@@ -2728,7 +2728,14 @@ begin
     -- validate the scheduling config
     perform ai._validate_scheduling(scheduling);
 
+    -- validate the processing config
     perform ai._validate_processing(processing);
+
+    -- if scheduling is none then indexing must also be none
+    if scheduling operator(pg_catalog.->>) 'implementation' = 'none'
+    and indexing operator(pg_catalog.->>) 'implementation' != 'none' then
+        raise exception 'automatic indexing is not supported without scheduling. set indexing=>ai.indexing_none() when scheduling=>ai.scheduling_none()';
+    end if;
 
     -- grant select to source table
     perform ai._vectorizer_grant_to_source

--- a/projects/extension/sql/idempotent/012-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-api.sql
@@ -121,7 +121,14 @@ begin
     -- validate the scheduling config
     perform ai._validate_scheduling(scheduling);
 
+    -- validate the processing config
     perform ai._validate_processing(processing);
+
+    -- if scheduling is none then indexing must also be none
+    if scheduling operator(pg_catalog.->>) 'implementation' = 'none'
+    and indexing operator(pg_catalog.->>) 'implementation' != 'none' then
+        raise exception 'automatic indexing is not supported without scheduling. set indexing=>ai.indexing_none() when scheduling=>ai.scheduling_none()';
+    end if;
 
     -- grant select to source table
     perform ai._vectorizer_grant_to_source

--- a/projects/extension/tests/dump_restore/after.sql
+++ b/projects/extension/tests/dump_restore/after.sql
@@ -14,6 +14,7 @@ select ai.create_vectorizer
 , embedding=>ai.embedding_openai('text-embedding-3-small', 768)
 , chunking=>ai.chunking_character_text_splitter('content', 128, 10)
 , scheduling=>ai.scheduling_none()
+, indexing=>ai.indexing_none()
 , grant_to=>null
 );
 

--- a/projects/extension/tests/dump_restore/init.sql
+++ b/projects/extension/tests/dump_restore/init.sql
@@ -22,6 +22,7 @@ select ai.create_vectorizer
 , chunking=>ai.chunking_character_text_splitter('content', 128, 10)
 , formatting=>ai.formatting_python_template('title: $title published: $published $chunk')
 , scheduling=>ai.scheduling_none()
+, indexing=>ai.indexing_none()
 , grant_to=>null
 );
 

--- a/projects/extension/tests/privileges/init1.sql
+++ b/projects/extension/tests/privileges/init1.sql
@@ -21,6 +21,7 @@ select ai.create_vectorizer
 , embedding=>ai.embedding_openai('text-embedding-3-small', 768)
 , chunking=>ai.chunking_character_text_splitter('content', 128, 10)
 , scheduling=>ai.scheduling_none()
+, indexing=>ai.indexing_none()
 , grant_to=>array['fred', 'jill']
 );
 

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -1118,3 +1118,53 @@ def test_naming_collisions():
             );
             """)
             assert True
+
+
+def test_none_index_scheduling():
+    with psycopg.connect(
+        db_url("test"), autocommit=True, row_factory=namedtuple_row
+    ) as con:
+        with con.cursor() as cur:
+            cur.execute("create extension if not exists ai cascade")
+            cur.execute("create extension if not exists timescaledb")
+            cur.execute("create schema if not exists vec")
+            cur.execute("drop table if exists vec.note3")
+            cur.execute("""
+                create table vec.note3
+                ( id bigint not null primary key generated always as identity
+                , note text not null
+                )
+            """)
+
+            # create a vectorizer for the table. this should fail
+            # language=PostgreSQL
+            with pytest.raises(
+                psycopg.errors.RaiseException,
+                match=".*automatic indexing is not supported without scheduling",
+            ):
+                cur.execute("""
+                select ai.create_vectorizer
+                ( 'vec.note3'::regclass
+                , embedding=>ai.embedding_openai('text-embedding-3-small', 3)
+                , chunking=>ai.chunking_character_text_splitter('note')
+                , scheduling=> ai.scheduling_none()
+                , indexing=>ai.indexing_hnsw(min_rows=>10, m=>20)
+                , grant_to=>null
+                , enqueue_existing=>false
+                );
+                """)
+
+            # create a vectorizer for the table. this should succeed
+            # language=PostgreSQL
+            cur.execute("""
+            select ai.create_vectorizer
+            ( 'vec.note3'::regclass
+            , embedding=>ai.embedding_openai('text-embedding-3-small', 3)
+            , chunking=>ai.chunking_character_text_splitter('note')
+            , scheduling=> ai.scheduling_none()
+            , indexing=>ai.indexing_none()
+            , grant_to=>null
+            , enqueue_existing=>false
+            );
+            """)
+            assert True


### PR DESCRIPTION
we only support automatic index creation if scheduling is enabled. fail if indexing is not none but scheduling is none