### PR TITLE
feat: add polling mode to vectorizer cli

### DIFF
--- a/projects/pgai/Dockerfile
+++ b/projects/pgai/Dockerfile
@@ -1,11 +1,15 @@
 FROM python:3.12-slim
+ENV PYTHONDONTWRITEBYTECODE=1 \
+  PYTHONUNBUFFERED=1
+WORKDIR /app
 
-WORKDIR /build
-COPY ./ /build/
-RUN pip3 install -v --compile --root-user-action=ignore /build
-WORKDIR /
-RUN rm -r /build
+RUN useradd -ms /bin/bash pgaiuser
 
-ENV PATH=/usr/local/bin/:$PATH
-ENTRYPOINT [ "vectorizer" ]
-CMD ["--version"]
+COPY ./requirements.txt /app/
+RUN pip3 install --no-cache-dir --disable-pip-version-check --compile --root-user-action=ignore -r requirements.txt
+
+USER pgaiuser
+COPY pyproject.toml /app
+COPY pgai /app/pgai
+ENTRYPOINT [ "python", "-m", "pgai" ]
+CMD ["-c", "4"]

--- a/projects/pgai/requirements.txt
+++ b/projects/pgai/requirements.txt
@@ -10,3 +10,4 @@ datadog-lambda
 pgvector==0.3.3
 tiktoken==0.7.0
 typing_extensions==4.12.2
+pytimeparse==1.1.8


### PR DESCRIPTION
- Introduced `--poll-interval` option to specify the wait time before checking for new work after processing all available tasks.
- Added `--once` flag to exit the program after processing all available work in the queue.

Closes [AI-58](https://linear.app/timescale/issue/AI-58/modify-vectorizer-container-to-keep-running-and-log-status)