### PR TITLE
fix: enable using any key for the OPENAI_API_KEY secret

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -72,7 +72,6 @@ def get_vectorizer(db_url: str, vectorizer_id: int) -> Vectorizer | None:
                 vectorizer_id=vectorizer_id,
             )
             return None
-        
         secrets: dict[str, str | None] = {api_key_name: api_key}
         vectorizer = Vectorizer(**vectorizer)
         vectorizer.config.embedding.set_api_key(secrets)

--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -15,7 +15,6 @@ from psycopg.rows import dict_row, namedtuple_row
 from pytimeparse import parse  # type: ignore
 
 from .__init__ import __version__
-from .vectorizer.secrets import Secrets
 from .vectorizer.vectorizer import Vectorizer, Worker
 
 load_dotenv()
@@ -73,7 +72,8 @@ def get_vectorizer(db_url: str, vectorizer_id: int) -> Vectorizer | None:
                 vectorizer_id=vectorizer_id,
             )
             return None
-        secrets = Secrets(OPENAI_API_KEY=api_key)
+        
+        secrets: dict[str, str | None] = {api_key_name: api_key}
         vectorizer = Vectorizer(**vectorizer)
         vectorizer.config.embedding.set_api_key(secrets)
         return vectorizer

--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -106,7 +106,7 @@ class ApiKeyMixin:
             ValueError: If the API key is missing from the secrets.
         """
 
-        api_key = secrets[self.api_key_name] if self.api_key_name in secrets else None
+        api_key = secrets.get(self.api_key_name, None)
         if api_key is None:
             raise ValueError(f"missing API key: {self.api_key_name}")
         self._api_key_ = api_key

--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -15,8 +15,6 @@ from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 from typing_extensions import override
 
-from .secrets import Secrets
-
 MAX_RETRIES = 3
 
 TOKEN_CONTEXT_LENGTH_ERROR = "chunk exceeds model context length"
@@ -97,7 +95,7 @@ class ApiKeyMixin:
             raise ValueError("API key not set")
         return self._api_key_
 
-    def set_api_key(self, secrets: Secrets):
+    def set_api_key(self, secrets: dict[str, str | None]):
         """
         Sets the API key from the provided secrets.
 
@@ -107,7 +105,8 @@ class ApiKeyMixin:
         Raises:
             ValueError: If the API key is missing from the secrets.
         """
-        api_key = getattr(secrets, self.api_key_name)
+
+        api_key = secrets[self.api_key_name] if self.api_key_name in secrets else None
         if api_key is None:
             raise ValueError(f"missing API key: {self.api_key_name}")
         self._api_key_ = api_key

--- a/projects/pgai/pgai/vectorizer/lambda_handler.py
+++ b/projects/pgai/pgai/vectorizer/lambda_handler.py
@@ -9,7 +9,6 @@ from pydantic.dataclasses import dataclass
 
 from . import db
 from .processing import ProcessingDefault
-from .secrets import Secrets
 from .vectorizer import Vectorizer, Worker
 
 TIKTOKEN_CACHE_DIR = os.path.join(
@@ -22,7 +21,7 @@ logger = structlog.get_logger()
 @dataclass
 class UpdateEmbeddings:
     db: db.ConnInfo
-    secrets: Secrets
+    secrets: dict[str, str | None]
 
 
 @dataclass

--- a/projects/pgai/pgai/vectorizer/secrets.py
+++ b/projects/pgai/pgai/vectorizer/secrets.py
@@ -1,8 +1,0 @@
-from pydantic.dataclasses import dataclass
-
-
-@dataclass
-class Secrets:
-    """Secrets to be mapped into the event payload."""
-
-    OPENAI_API_KEY: str | None = None


### PR DESCRIPTION
This PR enables to use any other secret for the OpenAI API Key rather than hardcoded `OPENAI_API_KEY `.