### PR TITLE
cli: --once is a flag

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -161,6 +161,7 @@ class TimeDurationParamType(click.ParamType):
 @click.option(
     "--once",
     type=click.BOOL,
+    is_flag=True,
     default=False,
     show_default=True,
     help="Exit after processing all available work.",


### PR DESCRIPTION
Without being declared as a flag, --once will want to be passed a value (True or False), which is unnecessary.