### PR TITLE
feat: use commands for scoping the cli

### DIFF
--- a/build.py
+++ b/build.py
@@ -543,10 +543,10 @@ def test_server() -> None:
 
 def vectorizer() -> None:
     if where_am_i() == "host":
-        cmd = "docker exec -it pgai vectorizer --version"
+        cmd = "docker exec -it pgai pgai vectorizer-worker --version"
         subprocess.run(cmd, shell=True, check=True, env=os.environ, cwd=root_dir())
     else:
-        cmd = "vectorizer --version"
+        cmd = "pgai vectorizer-worker --version"
         subprocess.run(
             cmd,
             shell=True,

--- a/projects/pgai/Dockerfile
+++ b/projects/pgai/Dockerfile
@@ -11,5 +11,5 @@ RUN pip3 install --no-cache-dir --disable-pip-version-check --compile --root-use
 USER pgaiuser
 COPY pyproject.toml /app
 COPY pgai /app/pgai
-ENTRYPOINT [ "python", "-m", "pgai" ]
+ENTRYPOINT ["python", "-m", "pgai", "vectorizer", "worker"]
 CMD ["-c", "4"]

--- a/projects/pgai/pgai/__main__.py
+++ b/projects/pgai/pgai/__main__.py
@@ -1,4 +1,4 @@
-from .cli import run
+from .cli import cli
 
 if __name__ == "__main__":
-    run()
+    cli()

--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -117,7 +117,7 @@ class TimeDurationParamType(click.ParamType):
             )
 
 
-@click.command()
+@click.command(name="worker")
 @click.version_option(version=__version__)
 @click.option(
     "-d",
@@ -165,7 +165,7 @@ class TimeDurationParamType(click.ParamType):
     show_default=True,
     help="Exit after processing all available work.",
 )
-def run(
+def vectorizer_worker(
     db_url: str,
     vectorizer_ids: Sequence[int] | None,
     concurrency: int,
@@ -201,3 +201,19 @@ def run(
             return
         time.sleep(poll_interval)
         log.info(f"sleeping for {poll_interval_str} before polling for new work")
+
+
+@click.group()
+@click.version_option(version=__version__)
+def vectorizer():
+    pass
+
+
+@click.group()
+@click.version_option(version=__version__)
+def cli():
+    pass
+
+
+vectorizer.add_command(vectorizer_worker)
+cli.add_command(vectorizer)

--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -42,7 +42,7 @@ include = ["pgai*"]  # package names should match these glob patterns (["*"] by 
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-vectorizer = "pgai.cli:run"
+pgai = "pgai.cli:cli"
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Instead of the cli running directly the vectorizer worker, the worker has been moved to its own command. The entry point has been rename from vectorizer to pgai.

This will allow us to add other commands seamlessly in the future, without having to introduce breaking changes or multiple scripts.

The workflow will look like this:

```
$ pip install pgai
$ pgai --help
Usage: pgai [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.
  --help  Show this message and exit.

Commands:
  vectorizer

$ python -m pgai vectorizer --help
Usage: python -m pgai vectorizer [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  worker

$ pgai vectorizer worker --help
Usage: pgai vectorizer worker [OPTIONS]

Options:
  --version                       Show the version and exit.
  -d, --db-url TEXT               The database URL to connect to  [default:
                                  postgres://postgres@localhost:5432/postgres]
  -i, --vectorizer-id INTEGER     Only fetch work from the given vectorizer
                                  ids. If not provided, all vectorizers will
                                  be fetched.
  -c, --concurrency INTEGER RANGE
                                  [default: 1; x>=1]
  --log-level [DEBUG|INFO|WARN|ERROR|FATAL|CRITICAL]
  --poll-interval TIME DURATION   The interval, in duration string or integer
                                  (seconds), to wait before checking for new
                                  work after processing all available work in
                                  the queue.  [default: 5m]
  --once BOOLEAN                  Exit after processing all available work.
                                  [default: False]
  --help                          Show this message and exit.
```