### PR TITLE
build: don't build timescaledb or pgvectorscale from scratch

### DIFF
--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1.3-labs
 ARG PG_MAJOR
+ARG TIMESCALEDB_IMAGE=timescale/timescaledb-ha:pg${PG_MAJOR}
+FROM ${TIMESCALEDB_IMAGE} as timescaledb
+
+ARG PG_MAJOR
 FROM postgres:${PG_MAJOR}
 
 ENV WHERE_AM_I=docker
@@ -15,41 +19,19 @@ RUN set -e; \
     postgresql-${PG_MAJOR}-pgextwlist \
     postgresql-server-dev-${PG_MAJOR} \
     python3-pip \
-    build-essential \
-    pkg-config \
     make \
-    cmake \
-    clang \
     git \
     curl \
     vim
 
-# install timescaledb
-RUN set -e; \
-    mkdir -p /build/timescaledb; \
-    git clone https://github.com/timescale/timescaledb.git --branch 2.17.1 /build/timescaledb; \
-    cd /build/timescaledb;  \
-    bash ./bootstrap; \
-    cd build && make; \
-    make install; \
-    rm -rf /build/timescaledb
-
-# install pgvectorscale
-ARG RUSTFLAGS
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN set -e; \
-    rustup install stable; \
-    cargo install cargo-pgrx --version 0.12.5 --locked; \
-    cargo pgrx init --pg${PG_MAJOR} pg_config; \
-    mkdir -p /build/pgvectorscale; \
-    git clone --branch 0.4.0 https://github.com/timescale/pgvectorscale /build/pgvectorscale; \
-    cd /build/pgvectorscale/pgvectorscale; \
-    if [ -n "$RUSTFLAGS" ]; then \
-      export RUSTFLAGS=${RUSTFLAGS}; \
-    fi; \
-    cargo pgrx install --release --features pg${PG_MAJOR}; \
-    rm -rf /build/pgvectorscale
+# install timescaledb and pgvectorscale
+COPY --from=timescaledb /usr/share/postgresql/${PG_MAJOR}/extension/timescaledb--*.sql /usr/share/postgresql/${PG_MAJOR}/extension/
+COPY --from=timescaledb /usr/share/postgresql/${PG_MAJOR}/extension/vectorscale--*.sql /usr/share/postgresql/${PG_MAJOR}/extension/
+COPY --from=timescaledb /usr/share/postgresql/${PG_MAJOR}/extension/timescaledb.control /usr/share/postgresql/${PG_MAJOR}/extension/
+COPY --from=timescaledb /usr/share/postgresql/${PG_MAJOR}/extension/vectorscale.control /usr/share/postgresql/${PG_MAJOR}/extension/
+COPY --from=timescaledb /usr/lib/postgresql/${PG_MAJOR}/lib/timescaledb.so /usr/lib/postgresql/${PG_MAJOR}/lib/
+COPY --from=timescaledb /usr/lib/postgresql/${PG_MAJOR}/lib/timescaledb-*.so /usr/lib/postgresql/${PG_MAJOR}/lib/
+COPY --from=timescaledb /usr/lib/postgresql/${PG_MAJOR}/lib/vectorscale-*.so /usr/lib/postgresql/${PG_MAJOR}/lib/
 
 # install pgspot
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import platform
 import re
 import os
 import shutil
@@ -503,12 +502,8 @@ def format_py() -> None:
 
 
 def docker_build() -> None:
-    if platform.machine().lower() in {"i386", "i686", "x86_64"}:
-        rust_flags = "--build-arg RUSTFLAGS='-C target-feature=+avx2,+fma'"
-    else:
-        rust_flags = ""
     subprocess.run(
-        f"""docker build --build-arg PG_MAJOR={pg_major()} {rust_flags} -t pgai-ext .""",
+        f"""docker build --build-arg PG_MAJOR={pg_major()} -t pgai-ext .""",
         shell=True,
         check=True,
         env=os.environ,


### PR DESCRIPTION
the vast majority of the time spend in CI is on building the timescaledb and pgvectorscale extensions. let's avoid that