### PR TITLE
Fix interpolation call: target_schema to target_name

### DIFF
--- a/projects/extension/sql/idempotent/013-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/013-vectorizer-api.sql
@@ -116,7 +116,7 @@ begin
 
     -- make sure target table name is available
     if pg_catalog.to_regclass(pg_catalog.format('%I.%I', target_schema, target_table)) is not null then
-        raise exception 'an object named %.% already exists. specify an alternate destination or target_table explicitly', target_schema, target_schema;
+        raise exception 'an object named %.% already exists. specify an alternate destination or target_table explicitly', target_schema, target_table;
     end if;
 
     -- make sure queue table name is available


### PR DESCRIPTION
I just found an error showing the following message:

```
 ERROR:  an object named public.public already exists. specify an alternate destination or target_table explicitly 
```
 
 Digging the code I see the table name was missing and the schema was repeated.
 
 
 ## How to test
 
 1. create a table
 2. create a vectorizer based on the table
 3. drop the table
 4. `truncate ai.vectorizer cascade`;
 5. repeat step 1 and then step 2 will fail.