### PR TITLE
perf: vector columns use storage main

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -116,6 +116,7 @@ begin
     into strict _pk_cols
     from pg_catalog.jsonb_to_recordset(source_pk) x(pknum int, attname name)
     ;
+
     select pg_catalog.format
     ( $sql$
     create table %I.%I
@@ -123,7 +124,7 @@ begin
     , %s
     , chunk_seq int not null
     , chunk text not null
-    , embedding @extschema:vector@.vector(%L) not null
+    , embedding @extschema:vector@.vector(%L) storage main not null
     , unique (%s, chunk_seq)
     , foreign key (%s) references %I.%I (%s) on delete cascade
     )

--- a/projects/extension/sql/incremental/003-vec-storage.sql
+++ b/projects/extension/sql/incremental/003-vec-storage.sql
@@ -1,0 +1,31 @@
+
+-- switch the vector columns from storage external to storage main
+do language plpgsql $block$
+declare
+    _sql pg_catalog.text;
+begin
+    set local search_path = pg_catalog, pg_temp;
+
+    for _sql in
+    (
+        select pg_catalog.format
+        ( $sql$alter table %I.%I alter column embedding set storage main$sql$
+        , v.target_schema
+        , v.target_table
+        )
+        from ai.vectorizer v
+        inner join pg_catalog.pg_class k on (k.relname operator(pg_catalog.=) v.target_table)
+        inner join pg_catalog.pg_namespace n
+            on (k.relnamespace operator(pg_catalog.=) n.oid and n.nspname operator(pg_catalog.=) v.target_schema)
+        inner join pg_catalog.pg_attribute a on (k.oid operator(pg_catalog.=) a.attrelid)
+        where a.attname operator(pg_catalog.=) 'embedding'
+        and a.attstorage not in ('m', 'p') -- not main or plain
+    )
+    loop
+        raise info '%', _sql;
+        execute _sql;
+        commit;
+        set local search_path = pg_catalog, pg_temp;
+    end loop;
+end;
+$block$;

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -117,7 +117,7 @@ TARGET_TABLE = """
  published      | timestamp with time zone |           | not null |                   | plain    |             |              | 
  chunk_seq      | integer                  |           | not null |                   | plain    |             |              | 
  chunk          | text                     |           | not null |                   | extended |             |              | 
- embedding      | vector(768)              |           | not null |                   | external |             |              | 
+ embedding      | vector(768)              |           | not null |                   | main     |             |              | 
 Indexes:
     "blog_embedding_store_pkey" PRIMARY KEY, btree (embedding_uuid)
     "blog_embedding_store_title_published_chunk_seq_key" UNIQUE CONSTRAINT, btree (title, published, chunk_seq)


### PR DESCRIPTION
Based on prior benchmarking, using storage plain (rather than extended/external) for vector columns performs much better. Unfortunately, it is difficult to determine whether a target table row will definitively fit on a single postgres page. Therefore, we will assign storage main to the vector columns, which will keep them inline unless they won't fit and toast otherwise.

NOTE: We will set storage to main for existing vectorizers (unless they have been already manually set to main or plain), but this will not take effect until a table rewrite happens. This can be done with `CLUSTER` or `VACUUM FULL` and may take a while depending on the size of the table.

>The TOAST management code recognizes four different strategies for storing TOAST-able columns on disk:
>
>PLAIN prevents either compression or out-of-line storage. This is the only possible strategy for columns of non-TOAST-able data types.
>
>EXTENDED allows both compression and out-of-line storage. This is the default for most TOAST-able data types. Compression will be attempted first, then out-of-line storage if the row is still too big.
>
>EXTERNAL allows out-of-line storage but not compression. Use of EXTERNAL will make substring operations on wide text and bytea columns faster (at the penalty of increased storage space) because these operations are optimized to fetch only the required parts of the out-of-line value when it is not compressed.
>
>MAIN allows compression but not out-of-line storage. (Actually, out-of-line storage will still be performed for such columns, but only as a last resort when there is no other way to make the row small enough to fit on a page.)

https://www.postgresql.org/docs/17/storage-toast.html#STORAGE-TOAST-ONDISK