### PR TITLE
add event triggers to handle table changes

### DIFF
--- a/projects/extension/tests/contents/output.expected
+++ b/projects/extension/tests/contents/output.expected
@@ -4,6 +4,7 @@ CREATE EXTENSION
                                                                                                    Objects in extension "ai"
                                                                                                       Object description                                                                                                       
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ event trigger _vectorizer_handle_drops
  function ai.anthropic_generate(text,jsonb,integer,text,text,double precision,integer,text,text,text[],double precision,jsonb,jsonb,integer,double precision)
  function ai.chunking_character_text_splitter(name,integer,integer,text,boolean)
  function ai.chunking_recursive_character_text_splitter(name,integer,integer,text[],boolean)
@@ -69,6 +70,7 @@ CREATE EXTENSION
  function ai._vectorizer_create_view(name,name,name,name,jsonb,name,name,name[])
  function ai._vectorizer_grant_to_source(name,name,name[])
  function ai._vectorizer_grant_to_vectorizer(name[])
+ function ai._vectorizer_handle_drops()
  function ai._vectorizer_job(integer,jsonb)
  function ai.vectorizer_queue_pending(integer)
  function ai._vectorizer_schedule_job(integer,jsonb)
@@ -83,7 +85,7 @@ CREATE EXTENSION
  table ai.vectorizer_errors
  view ai.secret_permissions
  view ai.vectorizer_status
-(79 rows)
+(81 rows)
 
                                     Table "ai._secret_permissions"
  Column | Type | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 

--- a/projects/extension/tests/privileges/function.expected
+++ b/projects/extension/tests/privileges/function.expected
@@ -72,6 +72,10 @@
  f       | bob   | execute   | no      | ai     | _vectorizer_grant_to_vectorizer(grant_to name[])
  f       | fred  | execute   | no      | ai     | _vectorizer_grant_to_vectorizer(grant_to name[])
  f       | jill  | execute   | YES     | ai     | _vectorizer_grant_to_vectorizer(grant_to name[])
+ f       | alice | execute   | YES     | ai     | _vectorizer_handle_drops()
+ f       | bob   | execute   | no      | ai     | _vectorizer_handle_drops()
+ f       | fred  | execute   | no      | ai     | _vectorizer_handle_drops()
+ f       | jill  | execute   | YES     | ai     | _vectorizer_handle_drops()
  p       | alice | execute   | YES     | ai     | _vectorizer_job(IN job_id integer, IN config jsonb)
  p       | bob   | execute   | no      | ai     | _vectorizer_job(IN job_id integer, IN config jsonb)
  p       | fred  | execute   | no      | ai     | _vectorizer_job(IN job_id integer, IN config jsonb)
@@ -288,5 +292,5 @@
  f       | bob   | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer)
  f       | fred  | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer)
  f       | jill  | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer)
-(288 rows)
+(292 rows)
 


### PR DESCRIPTION
Adds an event trigger to detect when a source, queue, or target table associated with a vectorizer is dropped. The event trigger calls ai.drop_vectorizer to clean up the mess.

a vectorizer has:

1. source table
2. queue table
3. target table
4. view
5. trigger
6. func backing the trigger
7. row in the ai.vectorizer table

- a user could drop/rename/move any or all of 1-6
- a user could delete the row from the ai.vectorizer table

doing either of those *could royally screw up the vectorizer

- trying to handle alter table... rename... is basically impossible without writing C
- trying to handle alter table... set schema... is basically impossible without writing C

so i'm focussed on drop table

- a superuser can drop anything
- the owner of a table can drop a table
- the owner of a schema can drop a table in it whether or not they own the table

as coded, only the owner of a table can create a vectorizer on it

and because our functions are security invoker, these objects are also owned by the source table owner:

- queue table
- target table
- view
- trigger
- func backing the trigger

so, if the event trigger is triggered because a superuser or the owner of the source table drops one of the tables, then we're good

If one of the tables is owned by user A in a schema owned by user B and user B drops the table, then we could be in the situation where drop_vectorizer might fail, because the other associated objects are in schemas NOT owned by user B

I've tried to check the ownership of the table being dropped. Unfortunately, by the time the event trigger is called (ddl_command_end) the pg_catalog has already been updated. So, I don't have the requisite breadcrumbs to track this down. (edited) 


## Renames and Moves

I considered handling these:

- `alter table ... rename to ...`
- `alter table ... set schema ...`

We cannot *reasonably handle source table renames. 

When the event trigger fires for an `ddl_command_end`, we use `pg_event_trigger_ddl_commands()` to find out what happened. 

- `objid` returns the oid of the table, but we don't/can't store the table's oid in `ai.vectorizer`
- we can join `objid` to `pg_class` but the `relname` has already been changed at this point
- similarly, `object_identity` contains the new table name
- command is of type `pg_ddl_command` which cannot be worked with except from C
- we can't even tell for sure that this is a rename event
- we *could try to use the `objid` to see if the table has a trigger on it matching a trigger matching a vectorizer and see if the `relname` doesn't match the row from the table….. hmm… but this feels pretty flimsy and would only have a chance of working for the source table (not the queue or target)

>pg_event_trigger_ddl_commands returns a list of DDL commands executed by each user action, when invoked in a function attached to a ddl_command_end event trigger. If called in any other context, an error is raised.

https://www.postgresql.org/docs/17/functions-event-triggers.html#PG-EVENT-TRIGGER-DDL-COMMAND-END-FUNCTIONS

>A trigger definition can also specify a WHEN condition so that, for example, a ddl_command_start trigger can be fired only for particular commands which the user wishes to intercept. A common use of such triggers is to restrict the range of DDL operations which users may perform.

https://www.postgresql.org/docs/17/event-trigger-definition.html

>You need a C function.

https://www.postgresql.org/message-id/20190712222343.GA26924%40alvherre.pgsql

NOTE: I implemented enough of this event trigger to try everything I could.