### PR TITLE
docs: update docker-compose command

### DIFF
--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -41,7 +41,7 @@ On your local machine:
 
 1. **Start the database**
    ```shell
-    docker-compose up -d db
+    docker compose up -d db
     ```
 
 ## Create and run a vectorizer
@@ -103,12 +103,12 @@ To create and run a vectorizer, then query the auto-generated embeddings created
    
    In a new terminal, start the vectorizer worker:
    ```shell
-   docker-compose up -d vectorizer-worker
+   docker compose up -d vectorizer-worker
    ```
 
 1. **Check the vectorizer worker logs** 
    ```shell
-   docker-compose logs -f vectorizer-worker
+   docker compose logs -f vectorizer-worker
    ```
 
    You see the vectorizer worker pick up the table and process it.

--- a/docs/vectorizer-worker.md
+++ b/docs/vectorizer-worker.md
@@ -74,7 +74,7 @@ On your local machine:
 
 1. **Start the database**
    ```shell
-    docker-compose up -d db
+    docker compose up -d db
     ```
 
 1. **Connect to your self-hosted database**
@@ -88,7 +88,7 @@ On your local machine:
 
    In a new terminal, start the vectorizer worker:
    ```shell
-   docker-compose up -d vectorizer-worker
+   docker compose up -d vectorizer-worker
    ```
   
 ### Install the vectorizer worker Docker image
@@ -122,7 +122,7 @@ On your local machine:
 
    In a new terminal, start the vectorizer worker:
    ```shell
-   docker-compose up -d vectorizer-worker
+   docker compose up -d vectorizer-worker
    ```
 
    You can also use the run command


### PR DESCRIPTION
`docker-compose` only works on Compose v1.
For Compose v2, which was released 4 years ago, the command should be `docker compose`.