### PR TITLE
fix: make vectorizer worker poll for new vectorizers

### DIFF
--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -46,7 +46,7 @@ def vcr_():
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="class")
 def postgres_container():
     extension_dir = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "../../../extension/")

--- a/projects/pgai/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer.py
@@ -46,8 +46,8 @@ def test_vectorizer_internal():
         cur.execute("create extension if not exists ai cascade")
         pgai_version = cli.get_pgai_version(cur)
         assert pgai_version is not None
-        assert len(cli.get_vectorizer_ids(cur)) == 0
-        assert len(cli.get_vectorizer_ids(cur, [42, 19])) == 0
+        assert len(cli.get_vectorizer_ids(_db_url)) == 0
+        assert len(cli.get_vectorizer_ids(_db_url, [42, 19])) == 0
         cur.execute("create extension if not exists timescaledb")
         cur.execute("drop table if exists note0")
         cur.execute("""
@@ -97,10 +97,10 @@ def test_vectorizer_internal():
         vectorizer_expected = cur.fetchone()
 
         # test cli.get_vectorizer_ids
-        assert len(cli.get_vectorizer_ids(cur)) == 1
-        assert len(cli.get_vectorizer_ids(cur, [42, 19])) == 0
-        assert len(cli.get_vectorizer_ids(cur, [vectorizer_id, 19])) == 1
-        assert len(cli.get_vectorizer_ids(cur, [vectorizer_id])) == 1
+        assert len(cli.get_vectorizer_ids(_db_url)) == 1
+        assert len(cli.get_vectorizer_ids(_db_url, [42, 19])) == 0
+        assert len(cli.get_vectorizer_ids(_db_url, [vectorizer_id, 19])) == 1
+        assert len(cli.get_vectorizer_ids(_db_url, [vectorizer_id])) == 1
 
         # test cli.get_vectorizer
         vectorizer_actual = cli.get_vectorizer(_db_url, vectorizer_id)

--- a/projects/pgai/tests/vectorizer/test_vectorizer_cli.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer_cli.py
@@ -110,176 +110,252 @@ def test_params(request: pytest.FixtureRequest) -> tuple[int, int, int, str, str
     return request.param
 
 
-@pytest.mark.parametrize(
-    "test_params",
-    [
-        (
-            1,
-            1,
-            1,
-            "chunking_character_text_splitter('content')",
-            "formatting_python_template('$chunk')",
-        ),
-        (
-            4,
-            2,
-            2,
-            "chunking_character_text_splitter('content')",
-            "formatting_python_template('$chunk')",
-        ),
-    ],
-)
-def test_process_vectorizer(
-    cli_db: tuple[PostgresContainer, Connection],
-    cli_db_url: str,
-    configured_vectorizer_and_source_table: int,
-    monkeypatch: pytest.MonkeyPatch,
-    vcr_: Any,
-    test_params: tuple[int, int, int, str, str],
-):
-    """Test successful processing of vectorizer tasks"""
-    num_items, concurrency, batch_size, _, _ = test_params
-    _, conn = cli_db
-    # Insert pre-existing embedding for first item
-    with conn.cursor() as cur:
-        cur.execute("""
-           INSERT INTO
-           blog_embedding_store(embedding_uuid, id, chunk_seq, chunk, embedding)
-           VALUES (gen_random_uuid(), 1, 1, 'post_1',
-            array_fill(0, ARRAY[1536])::vector)
-        """)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    # When running the worker with cassette matching original test params
-    cassette = (
-        f"openai-character_text_splitter-chunk_value-"
-        f"items={num_items}-batch_size={batch_size}.yaml"
+class TestWithConfiguredVectorizer:
+    @pytest.mark.parametrize(
+        "test_params",
+        [
+            (
+                1,
+                1,
+                1,
+                "chunking_character_text_splitter('content')",
+                "formatting_python_template('$chunk')",
+            ),
+            (
+                4,
+                2,
+                2,
+                "chunking_character_text_splitter('content')",
+                "formatting_python_template('$chunk')",
+            ),
+        ],
     )
-    logging.getLogger("vcr").setLevel(logging.DEBUG)
-    with vcr_.use_cassette(cassette):
-        result = CliRunner().invoke(
-            vectorizer_worker,
-            [
-                "--db-url",
-                cli_db_url,
-                "--once",
-                "--vectorizer-id",
-                str(configured_vectorizer_and_source_table),
-                "--concurrency",
-                str(concurrency),
-            ],
-            catch_exceptions=False,
+    def test_process_vectorizer(
+        self,
+        cli_db: tuple[PostgresContainer, Connection],
+        cli_db_url: str,
+        configured_vectorizer_and_source_table: int,
+        monkeypatch: pytest.MonkeyPatch,
+        vcr_: Any,
+        test_params: tuple[int, int, int, str, str],
+    ):
+        """Test successful processing of vectorizer tasks"""
+        num_items, concurrency, batch_size, _, _ = test_params
+        _, conn = cli_db
+        # Insert pre-existing embedding for first item
+        with conn.cursor() as cur:
+            cur.execute("""
+               INSERT INTO
+               blog_embedding_store(embedding_uuid, id, chunk_seq, chunk, embedding)
+               VALUES (gen_random_uuid(), 1, 1, 'post_1',
+                array_fill(0, ARRAY[1536])::vector)
+            """)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        # When running the worker with cassette matching original test params
+        cassette = (
+            f"openai-character_text_splitter-chunk_value-"
+            f"items={num_items}-batch_size={batch_size}.yaml"
         )
+        logging.getLogger("vcr").setLevel(logging.DEBUG)
+        with vcr_.use_cassette(cassette):
+            result = CliRunner().invoke(
+                vectorizer_worker,
+                [
+                    "--db-url",
+                    cli_db_url,
+                    "--once",
+                    "--vectorizer-id",
+                    str(configured_vectorizer_and_source_table),
+                    "--concurrency",
+                    str(concurrency),
+                ],
+                catch_exceptions=False,
+            )
 
-    assert not result.exception
-    assert result.exit_code == 0
+        assert not result.exception
+        assert result.exit_code == 0
 
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT count(*) as count FROM blog_embedding_store;")
-        assert cur.fetchone()["count"] == num_items  # type: ignore
-
-
-@pytest.mark.parametrize(
-    "test_params",
-    [
-        (
-            2,
-            1,
-            2,
-            "chunking_recursive_character_text_splitter('content', 128, 10,"
-            " separators => array[E'\n\n'])",
-            "formatting_python_template('$chunk')",
-        )
-    ],
-)
-def test_document_exceeds_model_context_length(
-    cli_db: tuple[PostgresContainer, Connection],
-    cli_db_url: str,
-    configured_vectorizer_and_source_table: int,
-    monkeypatch: pytest.MonkeyPatch,
-    vcr_: Any,
-):
-    """Test handling of documents that exceed the model's token limit"""
-    _, conn = cli_db
-    # Given a vectorizer configuration
-    with conn.cursor(row_factory=dict_row) as cur:
-        long_content = "AGI" * 5000
-        cur.execute(
-            f"UPDATE blog SET CONTENT = '{long_content}' where id = '2'",
-        )
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-
-    # When running the worker
-    with vcr_.use_cassette("test_document_in_batch_too_long.yaml"):
-        result = CliRunner().invoke(
-            vectorizer_worker,
-            [
-                "--db-url",
-                cli_db_url,
-                "--once",
-                "--vectorizer-id",
-                str(configured_vectorizer_and_source_table),
-            ],
-            catch_exceptions=False,
-        )
-
-    assert result.exit_code == 0
-
-    # Then only the normal document should be embedded
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM blog_embedding_store ORDER BY id")
-        records = cur.fetchall()
-        assert len(records) == 1
-        record = records[0]
-
-        # Verify the embedded document
-        assert record["id"] == 1
-        assert record["chunk"] == "post_1"
-        assert (
-            record["embedding"]
-            == expected.embeddings["openai-character_text_splitter-chunk_value-1-1"]
-        )
-
-        # Check error was logged
-        cur.execute("SELECT * FROM ai.vectorizer_errors")
-        errors = cur.fetchall()
-        assert len(errors) == 1
-        error = errors[0]
-        assert error["message"] == "chunk exceeds model context length"
-        assert error["details"]["pk"]["id"] == 2
-        assert (
-            error["details"]["error_reason"]
-            == "chunk exceeds the text-embedding-ada-002"
-            " model context length of 8192 tokens"
-        )
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("SELECT count(*) as count FROM blog_embedding_store;")
+            assert cur.fetchone()["count"] == num_items  # type: ignore
 
 
-@pytest.mark.parametrize(
-    "test_params",
-    [
-        (
-            2,
-            1,
-            2,
-            "chunking_recursive_character_text_splitter('content')",
-            "formatting_python_template('$chunk')",
-        )
-    ],
-)
-def test_invalid_api_key_error(
-    cli_db: tuple[PostgresContainer, Connection],
-    cli_db_url: str,
-    configured_vectorizer_and_source_table: int,
-    monkeypatch: pytest.MonkeyPatch,
-    vcr_: Any,
-):
-    """Test that worker handles invalid API key appropriately"""
-    # Given an invalid API key
-    monkeypatch.setenv("OPENAI_API_KEY", "invalid")
-    _, conn = cli_db
+    @pytest.mark.parametrize(
+        "test_params",
+        [
+            (
+                2,
+                1,
+                2,
+                "chunking_recursive_character_text_splitter('content', 128, 10,"
+                " separators => array[E'\n\n'])",
+                "formatting_python_template('$chunk')",
+            )
+        ],
+    )
+    def test_document_exceeds_model_context_length(
+        self,
+        cli_db: tuple[PostgresContainer, Connection],
+        cli_db_url: str,
+        configured_vectorizer_and_source_table: int,
+        monkeypatch: pytest.MonkeyPatch,
+        vcr_: Any,
+    ):
+        """Test handling of documents that exceed the model's token limit"""
+        _, conn = cli_db
+        # Given a vectorizer configuration
+        with conn.cursor(row_factory=dict_row) as cur:
+            long_content = "AGI" * 5000
+            cur.execute(
+                f"UPDATE blog SET CONTENT = '{long_content}' where id = '2'",
+            )
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-    # When running the worker
-    with vcr_.use_cassette("test_invalid_api_key_error.yaml"):
+        # When running the worker
+        with vcr_.use_cassette("test_document_in_batch_too_long.yaml"):
+            result = CliRunner().invoke(
+                vectorizer_worker,
+                [
+                    "--db-url",
+                    cli_db_url,
+                    "--once",
+                    "--vectorizer-id",
+                    str(configured_vectorizer_and_source_table),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+
+        # Then only the normal document should be embedded
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("SELECT * FROM blog_embedding_store ORDER BY id")
+            records = cur.fetchall()
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify the embedded document
+            assert record["id"] == 1
+            assert record["chunk"] == "post_1"
+            assert (
+                record["embedding"]
+                == expected.embeddings["openai-character_text_splitter-chunk_value-1-1"]
+            )
+
+            # Check error was logged
+            cur.execute("SELECT * FROM ai.vectorizer_errors")
+            errors = cur.fetchall()
+            assert len(errors) == 1
+            error = errors[0]
+            assert error["message"] == "chunk exceeds model context length"
+            assert error["details"]["pk"]["id"] == 2
+            assert (
+                error["details"]["error_reason"]
+                == "chunk exceeds the text-embedding-ada-002"
+                " model context length of 8192 tokens"
+            )
+
+
+    @pytest.mark.parametrize(
+        "test_params",
+        [
+            (
+                2,
+                1,
+                2,
+                "chunking_recursive_character_text_splitter('content')",
+                "formatting_python_template('$chunk')",
+            )
+        ],
+    )
+    def test_invalid_api_key_error(
+        self,
+        cli_db: tuple[PostgresContainer, Connection],
+        cli_db_url: str,
+        configured_vectorizer_and_source_table: int,
+        monkeypatch: pytest.MonkeyPatch,
+        vcr_: Any,
+    ):
+        """Test that worker handles invalid API key appropriately"""
+        # Given an invalid API key
+        monkeypatch.setenv("OPENAI_API_KEY", "invalid")
+        _, conn = cli_db
+
+        # When running the worker
+        with vcr_.use_cassette("test_invalid_api_key_error.yaml"):
+            try:
+                CliRunner().invoke(
+                    vectorizer_worker,
+                    [
+                        "--db-url",
+                        cli_db_url,
+                        "--once",
+                        "--vectorizer-id",
+                        str(configured_vectorizer_and_source_table),
+                    ],
+                )
+            except openai.AuthenticationError as e:
+                assert e.code == 401
+
+        # Ensure there's an entry in the errors table
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("SELECT * FROM ai.vectorizer_errors")
+            records = cur.fetchall()
+            assert len(records) == 1
+            error = records[0]
+            assert error["id"] == configured_vectorizer_and_source_table
+            assert error["message"] == "embedding provider failed"
+            assert error["details"] == {
+                "provider": "openai",
+                "error_reason": "Error code: 401 - {'error': {'message': "
+                "'Incorrect API key provided: invalid."
+                " You can find your API key at"
+                " https://platform.openai.com/account/api-keys.',"
+                " 'type': 'invalid_request_error', 'param': None,"
+                " 'code': 'invalid_api_key'}}",
+            }
+
+
+    @pytest.mark.parametrize(
+        "test_params",
+        [
+            (
+                1,
+                1,
+                1,
+                "chunking_character_text_splitter('content')",
+                "formatting_python_template('$chunk')",
+            )
+        ],
+    )
+    def test_invalid_function_arguments(
+        self,
+        cli_db: tuple[PostgresContainer, Connection],
+        cli_db_url: str,
+        configured_vectorizer_and_source_table: int,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test that worker handles invalid embedding model arguments appropriately"""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        _, conn = cli_db
+
+        # And a vectorizer with invalid embedding dimensions
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE ai.vectorizer
+                SET config = jsonb_set(
+                    config,
+                    '{embedding,dimensions}',
+                    '128'::jsonb
+                )
+                WHERE id = %s
+            """,
+                (configured_vectorizer_and_source_table,),
+            )
+
+        # When running the worker
         try:
             CliRunner().invoke(
                 vectorizer_worker,
@@ -291,110 +367,28 @@ def test_invalid_api_key_error(
                     str(configured_vectorizer_and_source_table),
                 ],
             )
-        except openai.AuthenticationError as e:
-            assert e.code == 401
+        except ValueError as e:
+            assert str(e) == "dimensions must be 1536 for text-embedding-ada-002"
 
-    # Ensure there's an entry in the errors table
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM ai.vectorizer_errors")
-        records = cur.fetchall()
-        assert len(records) == 1
-        error = records[0]
-        assert error["id"] == configured_vectorizer_and_source_table
-        assert error["message"] == "embedding provider failed"
-        assert error["details"] == {
-            "provider": "openai",
-            "error_reason": "Error code: 401 - {'error': {'message': "
-            "'Incorrect API key provided: invalid."
-            " You can find your API key at"
-            " https://platform.openai.com/account/api-keys.',"
-            " 'type': 'invalid_request_error', 'param': None,"
-            " 'code': 'invalid_api_key'}}",
-        }
-
-
-@pytest.mark.parametrize(
-    "test_params",
-    [
-        (
-            1,
-            1,
-            1,
-            "chunking_character_text_splitter('content')",
-            "formatting_python_template('$chunk')",
-        )
-    ],
-)
-def test_invalid_function_arguments(
-    cli_db: tuple[PostgresContainer, Connection],
-    cli_db_url: str,
-    configured_vectorizer_and_source_table: int,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """Test that worker handles invalid embedding model arguments appropriately"""
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    _, conn = cli_db
-
-    # And a vectorizer with invalid embedding dimensions
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            UPDATE ai.vectorizer
-            SET config = jsonb_set(
-                config,
-                '{embedding,dimensions}',
-                '128'::jsonb
-            )
-            WHERE id = %s
-        """,
-            (configured_vectorizer_and_source_table,),
-        )
-
-    # When running the worker
-    try:
-        CliRunner().invoke(
-            vectorizer_worker,
-            [
-                "--db-url",
-                cli_db_url,
-                "--once",
-                "--vectorizer-id",
-                str(configured_vectorizer_and_source_table),
-            ],
-        )
-    except ValueError as e:
-        assert str(e) == "dimensions must be 1536 for text-embedding-ada-002"
-
-    # Then an error was logged
-    with conn.cursor(row_factory=dict_row) as cur:
-        cur.execute("SELECT * FROM ai.vectorizer_errors")
-        records = cur.fetchall()
-        assert len(records) == 1
-        error = records[0]
-        assert error["id"] == configured_vectorizer_and_source_table
-        assert error["message"] == "embedding provider failed"
-        assert error["details"] == {
-            "provider": "openai",
-            "error_reason": "dimensions must be 1536 for text-embedding-ada-002",
-        }
-
-
-@pytest.fixture
-def cli_db_no_pgai(
-    cli_db: tuple[PostgresContainer, Connection],
-) -> Generator[tuple[PostgresContainer, Connection], None, None]:
-    _, conn = cli_db
-    with conn.cursor() as cur:
-        cur.execute("DROP EXTENSION IF EXISTS ai CASCADE")
-    yield cli_db
+        # Then an error was logged
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("SELECT * FROM ai.vectorizer_errors")
+            records = cur.fetchall()
+            assert len(records) == 1
+            error = records[0]
+            assert error["id"] == configured_vectorizer_and_source_table
+            assert error["message"] == "embedding provider failed"
+            assert error["details"] == {
+                "provider": "openai",
+                "error_reason": "dimensions must be 1536 for text-embedding-ada-002",
+            }
 
 
 def test_worker_no_extension(
-    cli_db_no_pgai: tuple[PostgresContainer, Connection],  # noqa
-    cli_db_url: str,
+    postgres_container: PostgresContainer,
 ):
     """Test that the worker fails when pgai extension is not installed"""
-    result = CliRunner().invoke(vectorizer_worker, ["--db-url", cli_db_url, "--once"])
+    result = CliRunner().invoke(vectorizer_worker, ["--db-url", postgres_container.get_connection_url(), "--once"])
 
     assert result.exit_code == 1
     assert "the pgai extension is not installed" in result.output.lower()


### PR DESCRIPTION
The vectorizer worker (running in continuous mode) now checks for the presence of new vectorizers on each pass through its work loop. This ensures that it processes vectorizers which are added after the worker starts.