### PR TITLE
build: disallow changes to incremental files that have shipped

### DIFF
--- a/projects/extension/Makefile
+++ b/projects/extension/Makefile
@@ -58,6 +58,10 @@ uninstall-sql:
 uninstall-py:
 	@./build.py uninstall-py
 
+.PHONY: freeze
+freeze:
+	@./build.py freeze
+
 .PHONY: build-sql
 build-sql:
 	@./build.py build-sql

--- a/projects/extension/sql/incremental/frozen.txt
+++ b/projects/extension/sql/incremental/frozen.txt
@@ -1,0 +1,2 @@
+ce888ecfafec8c0cee61bbb454c0ae072f850966fc81ada7ca1389e89f9303e2 001-vectorizer.sql
+151670fbdf6461d082c5198fc66b800303ed21eacceae3a4897afbc4dd608174 002-secret_permissions.sql


### PR DESCRIPTION
Incremental SQL files are database migrations. They are tracked in the `ai.migration` table. They are intended to be executed exactly once and in a deterministic order. For this reason, once we have shipped a version of the extension, all incremental files that existed as of that version must not be changed. They are frozen. This PR enforces this policy.