### PR TITLE
chore: run pgai tests against extension from source

### DIFF
--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -1,11 +1,31 @@
 # syntax=docker/dockerfile:1.3-labs
-ARG PG_MAJOR
+ARG PG_MAJOR=16
 ARG TIMESCALEDB_IMAGE=timescale/timescaledb-ha:pg${PG_MAJOR}
 FROM ${TIMESCALEDB_IMAGE} as timescaledb
 
-ARG PG_MAJOR
-FROM postgres:${PG_MAJOR}
+FROM postgres:${PG_MAJOR} AS build-latest
+ENV PG_MAJOR=${PG_MAJOR}
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends make python3-pip git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /pgai
+COPY requirements.txt .
+COPY ai/__init__.py ai/
+RUN version=$(grep -oP '(?<=__version__ = ")[^"]*' ai/__init__.py) && \
+    mkdir -p /usr/local/lib/pgai/$version && \
+    pip3 install -v --no-deps --compile -t /usr/local/lib/pgai/$version -r requirements.txt
+COPY . .
+RUN make install-py build-sql install-sql
 
+FROM timescaledb as pgai-test-db
+ARG PG_MAJOR=16
+COPY --from=build-latest /usr/share/postgresql/${PG_MAJOR}/extension/ai--*.sql /usr/share/postgresql/${PG_MAJOR}/extension/
+COPY --from=build-latest /usr/share/postgresql/${PG_MAJOR}/extension/ai.control /usr/share/postgresql/${PG_MAJOR}/extension/ai.control
+COPY --from=build-latest /usr/local/lib/pgai/ /usr/local/lib/pgai/
+
+FROM postgres:${PG_MAJOR}
 ENV WHERE_AM_I=docker
 ENV DEBIAN_FRONTEND=noninteractive
 USER root

--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import tiktoken
 import vcr  # type:ignore
 from psycopg import sql
+from testcontainers.core.image import DockerImage  # type:ignore
 from testcontainers.postgres import PostgresContainer  # type:ignore
 
 from pgai.vectorizer.vectorizer import TIKTOKEN_CACHE_DIR
@@ -47,8 +48,14 @@ def vcr_():
 
 @pytest.fixture(scope="session")
 def postgres_container():
+    extension_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../../extension/")
+    )
+    image = DockerImage(path=extension_dir, tag="pgai-test-db").build(  # type: ignore
+        target="pgai-test-db"
+    )
     with PostgresContainer(
-        "timescale/timescaledb-ha:pg16",
+        image=str(image),
         username="tsdbquerier",
         password="my-password",
         dbname="tsdb",


### PR DESCRIPTION
Change pgai testcontainer to build the extension and copy the extension code to a timescaledb-ha container.

This will make CI run the pgai python library against the latest changes made to the extension, and surface breaking changes sooner.