### PR TITLE
fix: handle dropped columns when creating vectorizers

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -229,6 +229,7 @@ begin
         left outer join pg_catalog.jsonb_to_recordset(source_pk) x(attnum int) on (a.attnum operator(pg_catalog.=) x.attnum)
         where a.attrelid operator(pg_catalog.=) pg_catalog.format('%I.%I', source_schema, source_table)::regclass::oid
         and a.attnum operator(pg_catalog.>) 0
+        and not a.attisdropped
       )
     , target_schema, target_table
     , source_schema, source_table

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -201,6 +201,7 @@ def test_vectorizer_timescaledb():
                 , title text not null
                 , published timestamptz
                 , body text not null
+                , drop_me text
                 , primary key (title, published)
                 )
             """)
@@ -215,6 +216,9 @@ def test_vectorizer_timescaledb():
                 , ('how to make a sandwich', '2023-01-06'::timestamptz, 'put a slice of meat between two pieces of bread')
                 , ('how to make stir fry', '2022-01-06'::timestamptz, 'pick up the phone and order takeout')
             """)
+
+            # drop the drop_me column
+            cur.execute("alter table website.blog drop column drop_me")
 
             # create a vectorizer for the blog table
             # language=PostgreSQL


### PR DESCRIPTION
Currently, if the source table has had a column dropped, `create_vectorizer` will fail. This PR fixes this bug.