### PR TITLE
fix: prevent vectorizer status view from failing if missing privs

### DIFF
--- a/projects/extension/sql/idempotent/013-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/013-vectorizer-api.sql
@@ -543,8 +543,13 @@ select
 , pg_catalog.format('%I.%I', v.source_schema, v.source_table) as source_table
 , pg_catalog.format('%I.%I', v.target_schema, v.target_table) as target_table
 , pg_catalog.format('%I.%I', v.view_schema, v.view_name) as "view"
-, case when v.queue_table is not null then
-    ai.vectorizer_queue_pending(v.id)
+, case when v.queue_table is not null and
+    pg_catalog.has_table_privilege
+    ( current_user
+    , pg_catalog.format('%I.%I', v.queue_schema, v.queue_table)
+    , 'select'
+    )
+    then ai.vectorizer_queue_pending(v.id)
   else 0
   end as pending_items
 from ai.vectorizer v

--- a/projects/extension/tests/contents/output.expected
+++ b/projects/extension/tests/contents/output.expected
@@ -217,7 +217,7 @@ View definition:
     format('%I.%I'::text, target_schema, target_table) AS target_table,
     format('%I.%I'::text, view_schema, view_name) AS view,
         CASE
-            WHEN queue_table IS NOT NULL THEN ai.vectorizer_queue_pending(id)
+            WHEN queue_table IS NOT NULL AND has_table_privilege(CURRENT_USER, format('%I.%I'::text, queue_schema, queue_table), 'select'::text) THEN ai.vectorizer_queue_pending(id)
             ELSE 0::bigint
         END AS pending_items
    FROM ai.vectorizer v;


### PR DESCRIPTION
Currently, if you call the `ai.vectorizer_status` view and you do not have SELECT privs on one or more queue tables, the view will fail. This PR prevents the view from failing by returning 0 for queue pending for these vectorizers.