### PR TITLE
perf!: don't do an exact count by default in vectorizer_queue_pending

### DIFF
--- a/docs/vectorizer-api-reference.md
+++ b/docs/vectorizer-api-reference.md
@@ -1014,6 +1014,19 @@ Return the number of pending items for the vectorizer with ID 1:
   SELECT ai.vectorizer_queue_pending(1);
   ```
 
+A queue with a very large number of items may be slow to count. The optional 
+`exact_count` parameter is defaulted to false. When false, the count is limited.
+An exact count is returned if the queue has 10,000 or fewer items, and returns
+9223372036854775807 (the max bigint value) if there are greater than 10,000 
+items.
+
+To get an exact count, regardless of queue size, set the optional parameter to
+`true` like this:
+
+  ```sql
+  SELECT ai.vectorizer_queue_pending(1, exact_count=>true);
+  ```
+
 #### Parameters
 
 `ai.vectorizer_queue_pending function` takes the following parameters:
@@ -1021,6 +1034,7 @@ Return the number of pending items for the vectorizer with ID 1:
 |Name| Type | Default | Required | Description |
 |-|------|-|-|-|
 |vectorizer_id| int  | -|✔|The identifier of the vectorizer you want to check|
+|exact_count| bool | false |✖|If true, return exact count. If false, capped at 10,000|
 
 
 ### Returns

--- a/projects/extension/sql/incremental/005-vectorizer-queue-pending.sql
+++ b/projects/extension/sql/incremental/005-vectorizer-queue-pending.sql
@@ -1,0 +1,6 @@
+
+-- we added a new parameter which changes the signature producing a new function
+-- drop the old function if it exists from a prior extension version
+-- we cascade drop because the ai.vectorizer_status view depends on this function
+-- we'll immediate recreate the view, so we should be good
+drop function if exists ai.vectorizer_queue_pending(int) cascade;

--- a/projects/extension/tests/contents/output.expected
+++ b/projects/extension/tests/contents/output.expected
@@ -72,7 +72,7 @@ CREATE EXTENSION
  function ai._vectorizer_grant_to_vectorizer(name[])
  function ai._vectorizer_handle_drops()
  function ai._vectorizer_job(integer,jsonb)
- function ai.vectorizer_queue_pending(integer)
+ function ai.vectorizer_queue_pending(integer,boolean)
  function ai._vectorizer_schedule_job(integer,jsonb)
  function ai._vectorizer_should_create_vector_index(ai.vectorizer)
  function ai._vectorizer_source_pk(regclass)

--- a/projects/extension/tests/privileges/function.expected
+++ b/projects/extension/tests/privileges/function.expected
@@ -288,9 +288,9 @@
  f       | bob   | execute   | no      | ai     | scheduling_timescaledb(schedule_interval interval, initial_start timestamp with time zone, fixed_schedule boolean, timezone text)
  f       | fred  | execute   | no      | ai     | scheduling_timescaledb(schedule_interval interval, initial_start timestamp with time zone, fixed_schedule boolean, timezone text)
  f       | jill  | execute   | YES     | ai     | scheduling_timescaledb(schedule_interval interval, initial_start timestamp with time zone, fixed_schedule boolean, timezone text)
- f       | alice | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer)
- f       | bob   | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer)
- f       | fred  | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer)
- f       | jill  | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer)
+ f       | alice | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
+ f       | bob   | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
+ f       | fred  | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
+ f       | jill  | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
 (292 rows)
 


### PR DESCRIPTION
Previously, we counted every row in the queue in `ai.vectorizer_queue_pending`, which could be very slow for large queues. Now, we limit 10,001 by default and add an `exact_count` bool parameter, which can be used to get an exact count if desired.