### PR TITLE
fix: vectorizer_status return null if no queue or missing privs

### DIFF
--- a/projects/extension/sql/idempotent/013-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/013-vectorizer-api.sql
@@ -550,7 +550,7 @@ select
     , 'select'
     )
     then ai.vectorizer_queue_pending(v.id)
-  else 0
+  else null
   end as pending_items
 from ai.vectorizer v
 ;

--- a/projects/extension/tests/contents/output.expected
+++ b/projects/extension/tests/contents/output.expected
@@ -218,7 +218,7 @@ View definition:
     format('%I.%I'::text, view_schema, view_name) AS view,
         CASE
             WHEN queue_table IS NOT NULL AND has_table_privilege(CURRENT_USER, format('%I.%I'::text, queue_schema, queue_table), 'select'::text) THEN ai.vectorizer_queue_pending(id)
-            ELSE 0::bigint
+            ELSE NULL::bigint
         END AS pending_items
    FROM ai.vectorizer v;
 


### PR DESCRIPTION
If a vectorizer has no queue table, or the user does not have select privileges on the queue table we will now return null for the pending_items column in the vectorizer_status view.