### PR TITLE
chore: a new database for each test

### DIFF
--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -46,7 +46,7 @@ def vcr_():
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def postgres_container():
     extension_dir = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "../../../extension/")


### PR DESCRIPTION
In 12c17809ec235d759e37eaa0898ea3274fea6319 we made tests less fragile by giving each test class its own fresh container, which also made the tests run a bit slower.

This change reuses the same container for all tests, but creates a new database for each test, achieving the same isolation, with low overhead.