### PR TITLE
chore: only run CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 permissions:
   contents: read
 


### PR DESCRIPTION
We were specifying that CI should be run on push, and on pull_request, this end up running jobs twice.

Push is the more useful of the two, because it means that you don't have to wait for a PR to be opened for the build to run against the changes.