### PR TITLE
feat: drop cascade for vectorizers

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -283,12 +283,12 @@ set search_path to pg_catalog, pg_temp
 
 -------------------------------------------------------------------------------
 -- _vectorizer_create_dependencies
-create or replace function ai._vectorizer_create_dependencies(vectorizer_id int)
+create or replace function ai._vectorizer_create_dependencies(vectorizer_id pg_catalog.int4)
 returns void as
 $func$
 declare
     _vec ai.vectorizer%rowtype;
-    _is_owner bool;
+    _is_owner pg_catalog.bool;
 begin
     -- this function is security definer since we need to insert into a catalog table
     -- fully-qualify everything and be careful of security holes
@@ -298,41 +298,52 @@ begin
     -- preventing this function from being abused
     select v.* into strict _vec
     from ai.vectorizer v
-    where v.id = vectorizer_id
+    where v.id operator(pg_catalog.=) vectorizer_id
     ;
 
     -- don't let anyone but the owner of the source table call this
-    select k.relowner operator(pg_catalog.=) pg_catalog.session_user()::regrole
+    select k.relowner operator(pg_catalog.=) pg_catalog.session_user()::pg_catalog.regrole
     into strict _is_owner
     from pg_catalog.pg_class k
     inner join pg_catalog.pg_namespace n on (k.relnamespace operator(pg_catalog.=) n.oid)
-    where k.oid operator(pg_catalog.=) pg_catalog.format('%I.%I', _vec.source_schema, _vec.source_table)::regclass::oid
+    where k.oid operator(pg_catalog.=) pg_catalog.format('%I.%I', _vec.source_schema, _vec.source_table)::pg_catalog.regclass::pg_catalog.oid
     ;
     if not _is_owner then
         raise exception 'only the owner of the source table may call ai._vectorizer_create_dependencies';
     end if;
 
     -- if we drop the source or the target with `cascade` it should drop the queue
+    -- if we drop the source with `cascade` it should drop the target
     -- there's no unique constraint on pg_depend so we manually prevent duplicate entries
     with x as
     (
         -- the queue table depends on the source table
         select
-         (select oid from pg_catalog.pg_class where relname = 'pg_class') as classid
-        , pg_catalog.format('%I.%I', _vec.queue_schema, _vec.queue_table)::regclass::oid as objid
+         (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as classid
+        , pg_catalog.format('%I.%I', _vec.queue_schema, _vec.queue_table)::pg_catalog.regclass::pg_catalog.oid as objid
         , 0 as objsubid
-        , (select oid from pg_catalog.pg_class where relname = 'pg_class') as refclassid
-        , pg_catalog.format('%I.%I', _vec.source_schema, _vec.source_table)::regclass::oid as refobjid
+        , (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as refclassid
+        , pg_catalog.format('%I.%I', _vec.source_schema, _vec.source_table)::pg_catalog.regclass::pg_catalog.oid as refobjid
         , 0 as refobjsubid
         , 'n' as deptype
         union all
         -- the queue table depends on the target table
         select
-         (select oid from pg_catalog.pg_class where relname = 'pg_class') as classid
-        , pg_catalog.format('%I.%I', _vec.queue_schema, _vec.queue_table)::regclass::oid as objid
+         (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as classid
+        , pg_catalog.format('%I.%I', _vec.queue_schema, _vec.queue_table)::pg_catalog.regclass::pg_catalog.oid as objid
         , 0 as objsubid
-        , (select oid from pg_catalog.pg_class where relname = 'pg_class') as refclassid
-        , pg_catalog.format('%I.%I', _vec.target_schema, _vec.target_table)::regclass::oid as refobjid
+        , (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as refclassid
+        , pg_catalog.format('%I.%I', _vec.target_schema, _vec.target_table)::pg_catalog.regclass::pg_catalog.oid as refobjid
+        , 0 as refobjsubid
+        , 'n' as deptype
+        union all
+        -- the target table depends on the source table
+        select
+         (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as classid
+        , pg_catalog.format('%I.%I', _vec.target_schema, _vec.target_table)::pg_catalog.regclass::pg_catalog.oid as objid
+        , 0 as objsubid
+        , (select oid from pg_catalog.pg_class where relname operator(pg_catalog.=) 'pg_class') as refclassid
+        , pg_catalog.format('%I.%I', _vec.source_schema, _vec.source_table)::pg_catalog.regclass::pg_catalog.oid as refobjid
         , 0 as refobjsubid
         , 'n' as deptype
     )
@@ -358,13 +369,13 @@ begin
     (
         select 1
         from pg_catalog.pg_depend d
-        where d.classid = x.classid
-        and d.objid = x.objid
-        and d.objsubid = x.objsubid
-        and d.refclassid = x.refclassid
-        and d.refobjid = x.refobjid
-        and d.refobjsubid = x.refobjsubid
-        and d.deptype = x.deptype
+        where d.classid operator(pg_catalog.=) x.classid
+        and d.objid operator(pg_catalog.=) x.objid
+        and d.objsubid operator(pg_catalog.=) x.objsubid
+        and d.refclassid operator(pg_catalog.=) x.refclassid
+        and d.refobjid operator(pg_catalog.=) x.refobjid
+        and d.refobjsubid operator(pg_catalog.=) x.refobjsubid
+        and d.deptype operator(pg_catalog.=) x.deptype
     )
     ;
 end

--- a/projects/extension/sql/idempotent/013-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/013-vectorizer-api.sql
@@ -253,6 +253,9 @@ begin
       )
     );
 
+    -- record dependencies in pg_depend
+    perform ai._vectorizer_create_dependencies(_vectorizer_id);
+
     -- grant select on the vectorizer table
     perform ai._vectorizer_grant_to_vectorizer(grant_to);
 

--- a/projects/extension/tests/contents/output.expected
+++ b/projects/extension/tests/contents/output.expected
@@ -63,6 +63,7 @@ CREATE EXTENSION
  function ai._validate_indexing(jsonb)
  function ai._validate_processing(jsonb)
  function ai._validate_scheduling(jsonb)
+ function ai._vectorizer_create_dependencies(integer)
  function ai._vectorizer_create_queue_table(name,name,jsonb,name[])
  function ai._vectorizer_create_source_trigger(name,name,name,name,name,jsonb)
  function ai._vectorizer_create_target_table(name,name,jsonb,name,name,integer,name[])
@@ -85,7 +86,7 @@ CREATE EXTENSION
  table ai.vectorizer_errors
  view ai.secret_permissions
  view ai.vectorizer_status
-(81 rows)
+(82 rows)
 
                                     Table "ai._secret_permissions"
  Column | Type | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 

--- a/projects/extension/tests/privileges/function.expected
+++ b/projects/extension/tests/privileges/function.expected
@@ -44,6 +44,10 @@
  f       | bob   | execute   | no      | ai     | _validate_scheduling(config jsonb)
  f       | fred  | execute   | no      | ai     | _validate_scheduling(config jsonb)
  f       | jill  | execute   | YES     | ai     | _validate_scheduling(config jsonb)
+ f       | alice | execute   | YES     | ai     | _vectorizer_create_dependencies(vectorizer_id integer)
+ f       | bob   | execute   | no      | ai     | _vectorizer_create_dependencies(vectorizer_id integer)
+ f       | fred  | execute   | no      | ai     | _vectorizer_create_dependencies(vectorizer_id integer)
+ f       | jill  | execute   | YES     | ai     | _vectorizer_create_dependencies(vectorizer_id integer)
  f       | alice | execute   | YES     | ai     | _vectorizer_create_queue_table(queue_schema name, queue_table name, source_pk jsonb, grant_to name[])
  f       | bob   | execute   | no      | ai     | _vectorizer_create_queue_table(queue_schema name, queue_table name, source_pk jsonb, grant_to name[])
  f       | fred  | execute   | no      | ai     | _vectorizer_create_queue_table(queue_schema name, queue_table name, source_pk jsonb, grant_to name[])
@@ -292,5 +296,5 @@
  f       | bob   | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
  f       | fred  | execute   | no      | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
  f       | jill  | execute   | YES     | ai     | vectorizer_queue_pending(vectorizer_id integer, exact_count boolean)
-(292 rows)
+(296 rows)
 

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -817,12 +817,12 @@ def test_drop_source():
             actual = cur.fetchone()[0]
             assert actual == 0
 
-            # does the target table exist? (it SHOULD)
+            # does the target table exist? (it should NOT)
             cur.execute(
                 f"select to_regclass('{vectorizer.target_schema}.{vectorizer.target_table}') is not null"
             )
             actual = cur.fetchone()[0]
-            assert actual is True
+            assert actual is False
 
             # does the queue table exist? (it should not b/c of cascade)
             cur.execute(
@@ -941,17 +941,17 @@ def test_drop_source_no_row():
             cur.execute("delete from ai.vectorizer where id = %s", (vectorizer_id,))
             assert cur.rowcount == 1
 
-            # drop the source table
+            # drop the source table with cascade
             cur.execute(
                 f"drop table {vectorizer.source_schema}.{vectorizer.source_table} cascade"
             )
 
-            # does the target table exist? (it SHOULD)
+            # does the target table exist? (it should NOT)
             cur.execute(
                 f"select to_regclass('{vectorizer.target_schema}.{vectorizer.target_table}') is not null"
             )
             actual = cur.fetchone()[0]
-            assert actual is True
+            assert actual is False
 
             # does the queue table exist? (it should not b/c of cascade)
             cur.execute(

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -803,12 +803,6 @@ def test_drop_source():
             assert cur.rownumber is not None
             pg_proc_oid = cur.fetchone()[0]
 
-            # have to drop the foreign key in order to drop the source
-            cur.execute(f"""
-                alter table {vectorizer.target_schema}.{vectorizer.target_table} 
-                drop constraint blog_drop_embedding_store_id_fkey restrict
-                """)
-
             # drop the source table
             # this should fire the event trigger and drop the vectorizer
             cur.execute(
@@ -877,6 +871,137 @@ def test_drop_source():
             )
             actual = cur.fetchone()[0]
             assert actual == 0
+
+
+def test_drop_source_no_row():
+    with psycopg.connect(
+        db_url("test"), autocommit=True, row_factory=namedtuple_row
+    ) as con:
+        with con.cursor() as cur:
+            cur.execute("create extension if not exists ai cascade")
+            cur.execute("create extension if not exists timescaledb")
+            cur.execute("drop table if exists public.drop_no_row")
+            cur.execute("""
+                create table public.drop_no_row
+                ( id serial not null primary key
+                , content text not null
+                )
+            """)
+
+            # create a vectorizer for the table
+            # language=PostgreSQL
+            cur.execute("""
+            select ai.create_vectorizer
+            ( 'public.drop_no_row'::regclass
+            , embedding=>ai.embedding_openai('text-embedding-3-small', 768)
+            , chunking=>ai.chunking_character_text_splitter('content', 128, 10)
+            , scheduling=>ai.scheduling_timescaledb()
+            , grant_to=>null
+            );
+            """)
+            vectorizer_id = cur.fetchone()[0]
+
+            cur.execute("select * from ai.vectorizer where id = %s", (vectorizer_id,))
+            vectorizer = cur.fetchone()
+
+            # does the target table exist? (it should)
+            cur.execute(
+                f"select to_regclass('{vectorizer.target_schema}.{vectorizer.target_table}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is True
+
+            # does the queue table exist? (it should)
+            cur.execute(
+                f"select to_regclass('{vectorizer.queue_schema}.{vectorizer.queue_table}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is True
+
+            # does the view exist? (it should)
+            cur.execute(
+                f"select to_regclass('{vectorizer.view_schema}.{vectorizer.view_name}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is True
+
+            # do the trigger and backing function exist? (it should)
+            cur.execute(f"""
+                select g.tgfoid
+                from pg_trigger g
+                where g.tgname = '{vectorizer.trigger_name}'
+                and g.tgrelid = '{vectorizer.source_schema}.{vectorizer.source_table}'::regclass::oid
+                ;
+            """)
+            assert cur.rownumber is not None
+            pg_proc_oid = cur.fetchone()[0]
+
+            # delete the vectorizer row !!!!
+            # this prevents the event trigger from working since it can't look up the vectorizer
+            cur.execute("delete from ai.vectorizer where id = %s", (vectorizer_id,))
+            assert cur.rowcount == 1
+
+            # drop the source table
+            cur.execute(
+                f"drop table {vectorizer.source_schema}.{vectorizer.source_table} cascade"
+            )
+
+            # does the target table exist? (it SHOULD)
+            cur.execute(
+                f"select to_regclass('{vectorizer.target_schema}.{vectorizer.target_table}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is True
+
+            # does the queue table exist? (it should not b/c of cascade)
+            cur.execute(
+                f"select to_regclass('{vectorizer.queue_schema}.{vectorizer.queue_table}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is False
+
+            # does the view exist? (it should not)
+            cur.execute(
+                f"select to_regclass('{vectorizer.view_schema}.{vectorizer.view_name}') is not null"
+            )
+            actual = cur.fetchone()[0]
+            assert actual is False
+
+            # does the trigger exist? (it should not)
+            cur.execute(f"""
+                select count(*)
+                from pg_trigger g
+                where g.tgname = '{vectorizer.trigger_name}'
+                ;
+            """)
+            actual = cur.fetchone()[0]
+            assert actual == 0
+
+            # does the func that backed the trigger exist? (it SHOULD)
+            # we didn't have the vectorizer row to look it up
+            cur.execute(
+                """
+                select count(*)
+                from pg_proc
+                where oid = %s
+            """,
+                (pg_proc_oid,),
+            )
+            actual = cur.fetchone()[0]
+            assert actual == 1
+
+            # does the timescaledb job exist? (it SHOULD)
+            # we didn't have the vectorizer row to look it up
+            cur.execute(
+                """
+                select count(*)
+                from timescaledb_information.jobs
+                where job_id = %s
+            """,
+                (vectorizer.config["scheduling"]["job_id"],),
+            )
+            actual = cur.fetchone()[0]
+            assert actual == 1
 
 
 def index_creation_tester(cur: psycopg.Cursor, vectorizer_id: int) -> None:


### PR DESCRIPTION
Adds entries into pg_depend such that when you `drop table <source-table> cascade` or `drop table <target-table> cascade` will also drop the queue table for vectorizers, and when you `drop table <source-table> cascade` it will also drop the target table too.