### PR TITLE
fix: allow members of source table to create vectorizer

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -301,8 +301,8 @@ begin
     where v.id operator(pg_catalog.=) vectorizer_id
     ;
 
-    -- don't let anyone but the owner of the source table call this
-    select k.relowner operator(pg_catalog.=) pg_catalog.session_user()::pg_catalog.regrole
+    -- don't let anyone but the owner (or members of the owner's role) of the source table call this
+    select pg_catalog.pg_has_role(pg_catalog.session_user(), k.relowner, 'MEMBER')
     into strict _is_owner
     from pg_catalog.pg_class k
     inner join pg_catalog.pg_namespace n on (k.relnamespace operator(pg_catalog.=) n.oid)

--- a/projects/extension/sql/idempotent/013-vectorizer-api.sql
+++ b/projects/extension/sql/idempotent/013-vectorizer-api.sql
@@ -69,14 +69,13 @@ begin
     end if;
 
     -- get source table name and schema name
-    select k.relname, n.nspname, k.relowner operator(pg_catalog.=) current_user::regrole
+    select k.relname, n.nspname, pg_catalog.pg_has_role(pg_catalog.current_user(), k.relowner, 'MEMBER')
     into strict _source_table, _source_schema, _is_owner
     from pg_catalog.pg_class k
     inner join pg_catalog.pg_namespace n on (k.relnamespace operator(pg_catalog.=) n.oid)
     where k.oid operator(pg_catalog.=) source
     ;
 
-    -- TODO: consider allowing (in)direct members of the role that owns the source table
     if not _is_owner then
         raise exception 'only the owner of the source table may create a vectorizer on it';
     end if;


### PR DESCRIPTION
In f68e73ac we added support for cascading the source/target table drop to the queue and other dependent objects. In adding this, we added a security definer function which asserts that the owner of the source table is calling the security definer function.

Due to how security definer functions work with `current_user`, the ownership check opted to use `session_user` to check ownership. This is problematic because in connections which use `SET ROLE`, the `session_user` may not be the same as `current_user`.

This commit relaxes the ownership check to check whether the current
user is a member of the role that owns the source table.
