### PR TITLE
chore: fix vectorizer worker docker labels and version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,21 +63,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up RELEASE_TAG
+        run: |
+          echo "RELEASE_TAG=${{ needs.release-please.outputs.tag_name }}" | sed 's/pgai-//' >> $GITHUB_ENV
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: timescale/pgai-vectorizer-worker
+          labels: |
+            org.opencontainers.image.description=A worker for self-hosted pgai vectorizers
+            org.opencontainers.image.title=pgai-vectorizer-worker
+          tags: |
+            type=raw,value=${{ env.RELEASE_TAG }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:projects/pgai"
           push: true
-          tags: timescale/pgai-vectorizer-worker:${{ needs.release-please.outputs.tag_name }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
In a multirepo setup, the release-please git tag contains the project prefix (`pgai-`). We were using this git tag as the docker container tag. This change strips the `pgai-` prefix from the git tag when generating the docker container tag. The resulting image name is: `timescale/pgai-vectorizer-worker:v<version>`.

Also overrides the description and title labels, which were derived from the github repository description and name respectively, so were not specific to the vectorizer worker.