### PR TITLE
fix: discord server link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: pgai discord
-    url: https://discord.com/channels/1246241636019605616/1246243698111676447
+    url: https://discord.gg/KRdHVXAmkp
     about: Get free help from the pgai community


### PR DESCRIPTION
I've clicked on the link and got an error message from discord because I hadn't joined the server. The new link is the one from the readme.