### PR TITLE
feat: text-to-sql

### DIFF
--- a/projects/extension/sql/idempotent/900-text-to-sql.sql
+++ b/projects/extension/sql/idempotent/900-text-to-sql.sql
@@ -406,3 +406,118 @@ begin
 end
 $block$;
 
+-------------------------------------------------------------------------------
+-- post_restore
+create or replace function ai.post_restore() returns void
+as $func$
+declare
+    _sql text;
+begin
+    -- disable vectorizer triggers on the ai.description table
+    for _sql in
+    (
+        select pg_catalog.format
+        ( $sql$alter table ai.description disable trigger %I$sql$
+        , g.tgname
+        )
+        from pg_catalog.pg_trigger g
+        where g.tgrelid operator(pg_catalog.=) 'ai.description'::pg_catalog.regclass::pg_catalog.oid
+        and g.tgname like '_vectorizer_src_trg_%'
+    )
+    loop
+        execute _sql;
+    end loop;
+
+    -- oids are likely invalid after a dump/restore
+    -- look up the new oids and true up
+    with x as
+    (
+        select
+          d.objtype
+        , d.objnames
+        , d.objargs
+        , x.classid
+        , x.objid
+        , x.objsubid
+        from
+        (
+            -- despite what the docs say, pg_get_object_address does NOT support everything that pg_identify_object_as_address does
+            -- view columns and materialized view columns will throw an error
+            -- https://github.com/postgres/postgres/blob/master/src/backend/catalog/objectaddress.c#L695
+            select *
+            from ai.description d
+            where d.objtype not in ('view column', 'materialized view column')
+        ) d
+        cross join lateral pg_catalog.pg_get_object_address
+        ( d.objtype
+        , d.objnames
+        , d.objargs
+        ) x
+    )
+    update ai.description as d set
+      classid = x.classid
+    , objid = x.objid
+    , objsubid = x.objsubid
+    from x
+    where d.objtype operator(pg_catalog.=) x.objtype
+    and d.objnames operator(pg_catalog.=) x.objnames
+    and d.objargs operator(pg_catalog.=) x.objargs
+    and (d.classid, d.objid, d.objsubid) operator(pg_catalog.!=) (x.classid, x.objid, x.objsubid) -- noop if nothing to change
+    ;
+
+    -- deal with view columns and materialized view columns
+    with x as
+    (
+        select
+          pg_catalog.to_regclass(pg_catalog.array_to_string(pg_catalog.trim_array(d.objnames, 1), '.')) as attrelid
+        , d.objnames[3] as attname
+        , d.objtype
+        , d.objnames
+        , d.objargs
+        from ai.description d
+        where d.objtype in ('view column', 'materialized view column')
+        and pg_catalog.array_length(d.objnames, 1) operator(pg_catalog.=) 3
+    )
+    , y as
+    (
+        select
+          'pg_catalog.pg_class'::pg_catalog.regclass::pg_catalog.oid as classid
+        , a.attrelid as objid
+        , a.attnum as objsubid
+        , x.objtype
+        , x.objnames
+        , x.objargs
+        from x
+        inner join pg_catalog.pg_attribute a
+        on (x.attrelid::pg_catalog.oid operator(pg_catalog.=) a.attrelid and x.attname operator(pg_catalog.=) a.attname)
+        where x.attrelid is not null
+    )
+    update ai.description as d set
+      classid = y.classid
+    , objid = y.objid
+    , objsubid = y.objsubid
+    from y
+    where d.objtype operator(pg_catalog.=) y.objtype
+    and d.objnames operator(pg_catalog.=) y.objnames
+    and d.objargs operator(pg_catalog.=) y.objargs
+    and (d.classid, d.objid, d.objsubid) operator(pg_catalog.!=) (y.classid, y.objid, y.objsubid) -- noop if nothing to change
+    ;
+
+    -- re-enable vectorizer triggers on the ai.description table
+    for _sql in
+    (
+        select pg_catalog.format
+        ( $sql$alter table ai.description enable trigger %I$sql$
+        , g.tgname
+        )
+        from pg_catalog.pg_trigger g
+        where g.tgrelid operator(pg_catalog.=) 'ai.description'::pg_catalog.regclass::pg_catalog.oid
+        and g.tgname like '_vectorizer_src_trg_%'
+    )
+    loop
+        execute _sql;
+    end loop;
+end;
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;

--- a/projects/extension/sql/idempotent/900-text-to-sql.sql
+++ b/projects/extension/sql/idempotent/900-text-to-sql.sql
@@ -1,0 +1,338 @@
+--FEATURE-FLAG: text_to_sql
+
+-------------------------------------------------------------------------------
+-- _set_description
+create or replace function ai._set_description
+( classid pg_catalog.oid
+, objid pg_catalog.oid
+, objsubid pg_catalog.int4
+, description pg_catalog.text
+) returns void
+as $func$
+    insert into ai.description
+    ( objtype
+    , objnames
+    , objargs
+    , classid
+    , objid
+    , objsubid
+    , description
+    )
+    select
+      x."type"
+    , x.object_names
+    , x.object_args
+    , classid
+    , objid
+    , objsubid
+    , _set_description.description
+    from pg_catalog.pg_identify_object_as_address
+    ( classid
+    , objid
+    , objsubid
+    ) x
+    on conflict on constraint description_pkey
+    do update set description = _set_description.description
+    ;
+$func$ language sql volatile security invoker
+set search_path to pg_catalog, pg_temp;
+
+-------------------------------------------------------------------------------
+-- set_table_description
+create or replace function ai.set_table_description
+( relation pg_catalog.regclass
+, description pg_catalog.text
+) returns void
+as $func$
+declare
+    _classid pg_catalog.oid;
+    _objid pg_catalog.oid;
+    _objsubid pg_catalog.int4;
+begin
+    _classid = 'pg_catalog.pg_class'::pg_catalog.regclass::pg_catalog.oid;
+    _objid = relation::pg_catalog.oid;
+    _objsubid = 0;
+
+    perform
+    from pg_catalog.pg_class k
+    where k.oid operator(pg_catalog.=) _objid
+    and k.relkind in ('r', 'f', 'p')
+    ;
+    if not found then
+        raise exception '% is not a table', relation::pg_catalog.text;
+    end if;
+
+    perform ai._set_description(_classid, _objid, _objsubid, description);
+end;
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp;
+
+-------------------------------------------------------------------------------
+-- set_view_description
+create or replace function ai.set_view_description
+( relation pg_catalog.regclass
+, description pg_catalog.text
+) returns void
+as $func$
+declare
+    _classid pg_catalog.oid;
+    _objid pg_catalog.oid;
+    _objsubid pg_catalog.int4;
+begin
+    _classid = 'pg_catalog.pg_class'::pg_catalog.regclass::pg_catalog.oid;
+    _objid = relation::pg_catalog.oid;
+    _objsubid = 0;
+
+    perform
+    from pg_catalog.pg_class k
+    where k.oid operator(pg_catalog.=) _objid
+    and k.relkind in ('v', 'm')
+    ;
+    if not found then
+        raise exception '% is not a view', relation::pg_catalog.text;
+    end if;
+
+    perform ai._set_description(_classid, _objid, _objsubid, description);
+end;
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp;
+
+-------------------------------------------------------------------------------
+-- set_column_description
+create or replace function ai.set_column_description
+( relation pg_catalog.regclass
+, column_name pg_catalog.name
+, description pg_catalog.text
+) returns void
+as $func$
+declare
+    _classid pg_catalog.oid;
+    _objid pg_catalog.oid;
+    _objsubid pg_catalog.int4;
+begin
+    _classid = 'pg_catalog.pg_class'::pg_catalog.regclass::pg_catalog.oid;
+    _objid = relation::pg_catalog.oid;
+    _objsubid = 0;
+
+    select a.attnum into _objsubid
+    from pg_catalog.pg_class k
+    inner join pg_catalog.pg_attribute a on (k.oid operator(pg_catalog.=) a.attrelid)
+    where k.oid operator(pg_catalog.=) _objid
+    and k.relkind in ('r', 'f', 'p', 'v', 'm')
+    and a.attnum operator(pg_catalog.>) 0
+    and a.attname operator(pg_catalog.=) column_name
+    ;
+    if not found then
+        raise exception '% column not found', column_name;
+    end if;
+
+    perform ai._set_description(_classid, _objid, _objsubid, description);
+end;
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp;
+
+-------------------------------------------------------------------------------
+-- set_function_description
+create or replace function ai.set_function_description
+( fn regprocedure
+, description text
+) returns void
+as $func$
+declare
+    _classid pg_catalog.oid;
+    _objid pg_catalog.oid;
+    _objsubid pg_catalog.int4;
+begin
+    _classid = 'pg_catalog.pg_proc'::pg_catalog.regclass::pg_catalog.oid;
+    _objid = fn::pg_catalog.oid;
+    _objsubid = 0;
+
+    perform ai._set_description(_classid, _objid, _objsubid, description);
+end;
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp;
+
+
+-------------------------------------------------------------------------------
+-- _description_handle_drop
+create or replace function ai._description_handle_drop()
+returns event_trigger as
+$func$
+declare
+    _rec record;
+begin
+    -- this function is security definer
+    -- fully-qualify everything and be careful of security holes
+    for _rec in
+    (
+        select
+          d.classid
+        , d.objid
+        , d.objsubid
+        , d.original
+        , d.normal
+        , d.is_temporary
+        , d.object_type
+        , d.schema_name
+        , d.object_name
+        , d.object_identity
+        , d.address_names
+        , d.address_args
+        from pg_catalog.pg_event_trigger_dropped_objects() d
+    )
+    loop
+        delete from ai.description
+        where objtype operator(pg_catalog.=) _rec.object_type
+        and objnames operator(pg_catalog.=) _rec.address_names
+        and objargs operator(pg_catalog.=) _rec.address_args
+        ;
+        if _rec.object_type in ('table', 'view') then
+            -- delete the columns too
+            delete from ai.description
+            where classid operator(pg_catalog.=) _rec.classid
+            and objid operator(pg_catalog.=) _rec.objid
+            ;
+        end if;
+    end loop;
+end;
+$func$
+language plpgsql volatile security definer -- definer on purpose!
+set search_path to pg_catalog, pg_temp
+;
+
+-- install the event trigger if not exists
+do language plpgsql $block$
+begin
+    -- if the event trigger already exists, noop
+    perform
+    from pg_catalog.pg_event_trigger g
+    where g.evtname operator(pg_catalog.=) '_description_handle_drop'
+    and g.evtfoid operator(pg_catalog.=) pg_catalog.to_regproc('ai._description_handle_drop')
+    ;
+    if found then
+        return;
+    end if;
+
+    create event trigger _description_handle_drop
+    on sql_drop
+    execute function ai._description_handle_drop();
+end
+$block$;
+
+-------------------------------------------------------------------------------
+-- _description_handle_ddl
+create or replace function ai._description_handle_ddl()
+returns event_trigger as
+$func$
+declare
+    _rec record;
+    _objtype pg_catalog.text;
+    _objnames pg_catalog.text[];
+    _objargs pg_catalog.text[];
+begin
+    -- this function is security definer
+    -- fully-qualify everything and be careful of security holes
+    for _rec in
+    (
+        select
+          d.classid
+        , d.objid
+        , d.objsubid
+        , d.command_tag
+        --, d.object_type
+        --, d.schema_name
+        --, d.object_identity
+        --, d.in_extension
+        --, d.command
+        from pg_catalog.pg_event_trigger_ddl_commands() d
+    )
+    loop
+        select
+          x."type"
+        , x.object_names
+        , x.object_args
+        into strict
+          _objtype
+        , _objnames
+        , _objargs
+        from pg_catalog.pg_identify_object_as_address
+        ( _rec.classid
+        , _rec.objid
+        , _rec.objsubid
+        ) x;
+
+        -- handles rename, set schema
+        update ai.description set
+          objtype = _objtype
+        , objnames = _objnames
+        , objargs = _objargs
+        where classid operator(pg_catalog.=) _rec.classid
+        and objid operator(pg_catalog.=) _rec.objid
+        and objsubid operator(pg_catalog.=) _rec.objsubid
+        and (objtype, objnames, objargs) operator(pg_catalog.!=) (_objtype, _objnames, _objargs)
+        ;
+        if found and _objtype in ('table', 'view') then
+            -- deal with columns
+            with a as
+            (
+                select
+                  _rec.classid
+                , a.attrelid as objid
+                , a.attnum as objsubid
+                from pg_catalog.pg_attribute a
+                where a.attrelid operator(pg_catalog.=) _rec.objid
+                and a.attnum operator(pg_catalog.>) 0
+            )
+            , x as
+            (
+                select
+                  a.classid
+                , a.objid
+                , a.objsubid
+                , x."type" as objtype
+                , x.object_names as objnames
+                , x.object_args as objargs
+                from a
+                cross join lateral pg_catalog.pg_identify_object_as_address
+                ( a.classid
+                , a.objid
+                , a.objsubid
+                ) x
+            )
+            update ai.description d set
+              objtype = x.objtype
+            , objnames = x.objnames
+            , objargs = x.objargs
+            from x
+            where d.classid operator(pg_catalog.=) x.classid
+            and d.objid operator(pg_catalog.=) x.objid
+            and d.objsubid operator(pg_catalog.=) x.objsubid
+            and (d.objtype, d.objnames, d.objargs) operator(pg_catalog.!=) (x.objtype, x.objnames, x.objargs)
+            ;
+        end if;
+    end loop;
+end
+$func$
+language plpgsql volatile security definer -- definer on purpose!
+set search_path to pg_catalog, pg_temp
+;
+
+-- install the event trigger if not exists
+do language plpgsql $block$
+begin
+    -- if the event trigger already exists, noop
+    perform
+    from pg_catalog.pg_event_trigger g
+    where g.evtname operator(pg_catalog.=) '_description_handle_ddl'
+    and g.evtfoid operator(pg_catalog.=) pg_catalog.to_regproc('ai._description_handle_ddl')
+    ;
+    if found then
+        return;
+    end if;
+
+    create event trigger _description_handle_ddl
+    on ddl_command_end
+    execute function ai._description_handle_ddl();
+end
+$block$;
+

--- a/projects/extension/sql/idempotent/999-privileges.sql
+++ b/projects/extension/sql/idempotent/999-privileges.sql
@@ -53,6 +53,7 @@ begin
         ( (false, 'ai', 'migration') -- only admins get any access to this table
         , (false, 'ai', '_secret_permissions') -- only admins get any access to this table
         , (false, 'ai', 'feature_flag') -- only admins get any access to this table
+        , (false, 'ai', 'post_restore') -- only admins get any access to this table
         )
         order by n.nspname, k.relname
     )

--- a/projects/extension/sql/incremental/900-text-to-sql.sql
+++ b/projects/extension/sql/incremental/900-text-to-sql.sql
@@ -1,0 +1,23 @@
+--FEATURE-FLAG: text_to_sql
+
+create table ai.description
+( objtype pg_catalog.text not null      -- required for dump/restore to function
+, objnames pg_catalog.text[] not null   -- required for dump/restore to function
+, objargs pg_catalog.text[] not null    -- required for dump/restore to function
+, classid pg_catalog.oid not null       -- required for event triggers to function
+, objid pg_catalog.oid not null         -- required for event triggers to function
+, objsubid pg_catalog.int4 not null     -- required for event triggers to function
+, description pg_catalog.text not null  -- the description
+, primary key (objtype, objnames, objargs)
+);
+create index on ai.description (classid, objid, objsubid);
+
+/*
+pg_identify_object_as_address translates
+classid + objid + objsubid -> objtype + objnames + objargs
+
+pg_get_object_address translates
+objtype + objnames + objargs -> classid + objid + objsubid
+
+and we can support descriptions for any db obj type that supports COMMENT
+*/

--- a/projects/extension/sql/incremental/900-text-to-sql.sql
+++ b/projects/extension/sql/incremental/900-text-to-sql.sql
@@ -11,6 +11,7 @@ create table ai.description
 , primary key (objtype, objnames, objargs)
 );
 create index on ai.description (classid, objid, objsubid);
+perform pg_catalog.pg_extension_config_dump('ai.description', '');
 
 /*
 pg_identify_object_as_address translates

--- a/projects/extension/tests/text_to_sql/.gitignore
+++ b/projects/extension/tests/text_to_sql/.gitignore
@@ -1,0 +1,4 @@
+describe_objects.sql
+describe_schemas.sql
+dump.sql
+*.snapshot

--- a/projects/extension/tests/text_to_sql/0.expected
+++ b/projects/extension/tests/text_to_sql/0.expected
@@ -1,0 +1,13 @@
+   objtype    |      objnames      |  objargs  |                description                
+--------------+--------------------+-----------+-------------------------------------------
+ function     | {public,life}      | {integer} | this is a comment about the life function
+ table        | {public,bob}       | {}        | this is a comment about the bob table
+ table column | {public,bob,bar}   | {}        | this is a comment about the bar column
+ table column | {public,bob,foo}   | {}        | this is a comment about the foo column
+ table column | {public,bob,id}    | {}        | this is a comment about the id column
+ view         | {public,bobby}     | {}        | this is a comment about the bob table
+ view column  | {public,bobby,bar} | {}        | this is a comment about the bar column
+ view column  | {public,bobby,foo} | {}        | this is a comment about the foo column
+ view column  | {public,bobby,id}  | {}        | this is a comment about the id column
+(9 rows)
+

--- a/projects/extension/tests/text_to_sql/1.expected
+++ b/projects/extension/tests/text_to_sql/1.expected
@@ -1,0 +1,13 @@
+   objtype    |      objnames      |  objargs  |                   description                    
+--------------+--------------------+-----------+--------------------------------------------------
+ function     | {public,life}      | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}       | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar}   | {}        | this is a comment about the bar column
+ table column | {public,bob,foo}   | {}        | this is a comment about the foo column
+ table column | {public,bob,id}    | {}        | this is a comment about the id column
+ view         | {public,bobby}     | {}        | this is a comment about the bob table
+ view column  | {public,bobby,bar} | {}        | this is a comment about the bar column
+ view column  | {public,bobby,foo} | {}        | this is a comment about the foo column
+ view column  | {public,bobby,id}  | {}        | this is a BETTER comment about the id column
+(9 rows)
+

--- a/projects/extension/tests/text_to_sql/10.expected
+++ b/projects/extension/tests/text_to_sql/10.expected
@@ -1,0 +1,8 @@
+   objtype    |    objnames     |      objargs      |                 description                  
+--------------+-----------------+-------------------+----------------------------------------------
+ function     | {maria,death}   | {integer,integer} | overloaded
+ table        | {maria,bob}     | {}                | this is a BETTER comment about the bob table
+ table column | {maria,bob,bar} | {}                | this is a comment about the bar column
+ table column | {maria,bob,id}  | {}                | this is a comment about the id column
+(4 rows)
+

--- a/projects/extension/tests/text_to_sql/10.expected
+++ b/projects/extension/tests/text_to_sql/10.expected
@@ -1,8 +1,9 @@
-   objtype    |    objnames     |      objargs      |                 description                  
---------------+-----------------+-------------------+----------------------------------------------
- function     | {maria,death}   | {integer,integer} | overloaded
- table        | {maria,bob}     | {}                | this is a BETTER comment about the bob table
- table column | {maria,bob,bar} | {}                | this is a comment about the bar column
- table column | {maria,bob,id}  | {}                | this is a comment about the id column
-(4 rows)
+   objtype    |     objnames      |      objargs      |                   description                    
+--------------+-------------------+-------------------+--------------------------------------------------
+ function     | {lucinda,death}   | {integer}         | this is a BETTER comment about the life function
+ function     | {lucinda,death}   | {integer,integer} | overloaded
+ table        | {lucinda,bob}     | {}                | this is a BETTER comment about the bob table
+ table column | {lucinda,bob,bar} | {}                | this is a comment about the bar column
+ table column | {lucinda,bob,id}  | {}                | this is a comment about the id column
+(5 rows)
 

--- a/projects/extension/tests/text_to_sql/11.expected
+++ b/projects/extension/tests/text_to_sql/11.expected
@@ -1,0 +1,5 @@
+ objtype  |   objnames    |      objargs      | description 
+----------+---------------+-------------------+-------------
+ function | {maria,death} | {integer,integer} | overloaded
+(1 row)
+

--- a/projects/extension/tests/text_to_sql/11.expected
+++ b/projects/extension/tests/text_to_sql/11.expected
@@ -1,5 +1,8 @@
- objtype  |   objnames    |      objargs      | description 
-----------+---------------+-------------------+-------------
- function | {maria,death} | {integer,integer} | overloaded
-(1 row)
+   objtype    |     objnames      |      objargs      |                 description                  
+--------------+-------------------+-------------------+----------------------------------------------
+ function     | {lucinda,death}   | {integer,integer} | overloaded
+ table        | {lucinda,bob}     | {}                | this is a BETTER comment about the bob table
+ table column | {lucinda,bob,bar} | {}                | this is a comment about the bar column
+ table column | {lucinda,bob,id}  | {}                | this is a comment about the id column
+(4 rows)
 

--- a/projects/extension/tests/text_to_sql/12.expected
+++ b/projects/extension/tests/text_to_sql/12.expected
@@ -1,0 +1,4 @@
+ objtype | objnames | objargs | description 
+---------+----------+---------+-------------
+(0 rows)
+

--- a/projects/extension/tests/text_to_sql/12.expected
+++ b/projects/extension/tests/text_to_sql/12.expected
@@ -1,4 +1,5 @@
- objtype | objnames | objargs | description 
----------+----------+---------+-------------
-(0 rows)
+ objtype  |    objnames     |      objargs      | description 
+----------+-----------------+-------------------+-------------
+ function | {lucinda,death} | {integer,integer} | overloaded
+(1 row)
 

--- a/projects/extension/tests/text_to_sql/13.expected
+++ b/projects/extension/tests/text_to_sql/13.expected
@@ -1,0 +1,4 @@
+ objtype | objnames | objargs | description 
+---------+----------+---------+-------------
+(0 rows)
+

--- a/projects/extension/tests/text_to_sql/2.expected
+++ b/projects/extension/tests/text_to_sql/2.expected
@@ -1,0 +1,13 @@
+   objtype    |      objnames      |  objargs  |                   description                    
+--------------+--------------------+-----------+--------------------------------------------------
+ function     | {public,death}     | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}       | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar}   | {}        | this is a comment about the bar column
+ table column | {public,bob,foo}   | {}        | this is a comment about the foo column
+ table column | {public,bob,id}    | {}        | this is a comment about the id column
+ view         | {public,bobby}     | {}        | this is a comment about the bob table
+ view column  | {public,bobby,bar} | {}        | this is a comment about the bar column
+ view column  | {public,bobby,foo} | {}        | this is a comment about the foo column
+ view column  | {public,bobby,id}  | {}        | this is a BETTER comment about the id column
+(9 rows)
+

--- a/projects/extension/tests/text_to_sql/3.expected
+++ b/projects/extension/tests/text_to_sql/3.expected
@@ -1,0 +1,13 @@
+   objtype    |      objnames      |  objargs  |                   description                    
+--------------+--------------------+-----------+--------------------------------------------------
+ function     | {public,death}     | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}       | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar}   | {}        | this is a comment about the bar column
+ table column | {public,bob,baz}   | {}        | this is a comment about the foo column
+ table column | {public,bob,id}    | {}        | this is a comment about the id column
+ view         | {public,bobby}     | {}        | this is a comment about the bob table
+ view column  | {public,bobby,bar} | {}        | this is a comment about the bar column
+ view column  | {public,bobby,foo} | {}        | this is a comment about the foo column
+ view column  | {public,bobby,id}  | {}        | this is a BETTER comment about the id column
+(9 rows)
+

--- a/projects/extension/tests/text_to_sql/4.expected
+++ b/projects/extension/tests/text_to_sql/4.expected
@@ -1,0 +1,13 @@
+   objtype    |        objnames        |  objargs  |                   description                    
+--------------+------------------------+-----------+--------------------------------------------------
+ function     | {public,death}         | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}           | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar}       | {}        | this is a comment about the bar column
+ table column | {public,bob,baz}       | {}        | this is a comment about the foo column
+ table column | {public,bob,id}        | {}        | this is a comment about the id column
+ view         | {public,frederick}     | {}        | this is a comment about the bob table
+ view column  | {public,frederick,bar} | {}        | this is a comment about the bar column
+ view column  | {public,frederick,foo} | {}        | this is a comment about the foo column
+ view column  | {public,frederick,id}  | {}        | this is a BETTER comment about the id column
+(9 rows)
+

--- a/projects/extension/tests/text_to_sql/5.expected
+++ b/projects/extension/tests/text_to_sql/5.expected
@@ -1,0 +1,9 @@
+   objtype    |     objnames     |  objargs  |                   description                    
+--------------+------------------+-----------+--------------------------------------------------
+ function     | {public,death}   | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}     | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar} | {}        | this is a comment about the bar column
+ table column | {public,bob,baz} | {}        | this is a comment about the foo column
+ table column | {public,bob,id}  | {}        | this is a comment about the id column
+(5 rows)
+

--- a/projects/extension/tests/text_to_sql/6.expected
+++ b/projects/extension/tests/text_to_sql/6.expected
@@ -1,0 +1,8 @@
+   objtype    |     objnames     |  objargs  |                   description                    
+--------------+------------------+-----------+--------------------------------------------------
+ function     | {public,death}   | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}     | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar} | {}        | this is a comment about the bar column
+ table column | {public,bob,id}  | {}        | this is a comment about the id column
+(4 rows)
+

--- a/projects/extension/tests/text_to_sql/7.expected
+++ b/projects/extension/tests/text_to_sql/7.expected
@@ -1,0 +1,8 @@
+   objtype    |     objnames     |  objargs  |                   description                    
+--------------+------------------+-----------+--------------------------------------------------
+ function     | {maria,death}    | {integer} | this is a BETTER comment about the life function
+ table        | {public,bob}     | {}        | this is a BETTER comment about the bob table
+ table column | {public,bob,bar} | {}        | this is a comment about the bar column
+ table column | {public,bob,id}  | {}        | this is a comment about the id column
+(4 rows)
+

--- a/projects/extension/tests/text_to_sql/8.expected
+++ b/projects/extension/tests/text_to_sql/8.expected
@@ -1,0 +1,8 @@
+   objtype    |    objnames     |  objargs  |                   description                    
+--------------+-----------------+-----------+--------------------------------------------------
+ function     | {maria,death}   | {integer} | this is a BETTER comment about the life function
+ table        | {maria,bob}     | {}        | this is a BETTER comment about the bob table
+ table column | {maria,bob,bar} | {}        | this is a comment about the bar column
+ table column | {maria,bob,id}  | {}        | this is a comment about the id column
+(4 rows)
+

--- a/projects/extension/tests/text_to_sql/9.expected
+++ b/projects/extension/tests/text_to_sql/9.expected
@@ -1,0 +1,9 @@
+   objtype    |    objnames     |      objargs      |                   description                    
+--------------+-----------------+-------------------+--------------------------------------------------
+ function     | {maria,death}   | {integer}         | this is a BETTER comment about the life function
+ function     | {maria,death}   | {integer,integer} | overloaded
+ table        | {maria,bob}     | {}                | this is a BETTER comment about the bob table
+ table column | {maria,bob,bar} | {}                | this is a comment about the bar column
+ table column | {maria,bob,id}  | {}                | this is a comment about the id column
+(5 rows)
+

--- a/projects/extension/tests/text_to_sql/extra.sql
+++ b/projects/extension/tests/text_to_sql/extra.sql
@@ -1,0 +1,67 @@
+
+-- TODO: remove feature flag
+select set_config('ai.enable_feature_flag_text_to_sql', 'true', false);
+create extension if not exists ai cascade;
+
+create schema bishop;
+
+create table public.xenomorph
+( id int not null primary key
+, foo text not null
+, bar timestamptz not null default now()
+);
+select ai.set_table_description ('public.xenomorph', 'description for xenomorph');
+select ai.set_column_description('public.xenomorph', 'id', 'description for xenomorph.id');
+select ai.set_column_description('public.xenomorph', 'foo', 'description for xenomorph.foo');
+select ai.set_column_description('public.xenomorph', 'bar', 'description for xenomorph.bar');
+
+create table bishop.ripley
+( id int not null primary key
+, foo text not null
+, bar timestamptz not null default now()
+);
+select ai.set_table_description('bishop.ripley', 'description for bishop.ripley');
+select ai.set_column_description('bishop.ripley', 'id', 'description for bishop.ripley.id');
+select ai.set_column_description('bishop.ripley', 'foo', 'description for bishop.ripley.foo');
+select ai.set_column_description('bishop.ripley', 'bar', 'description for bishop.ripley.bar');
+
+create view public.hicks as
+select * from bishop.ripley;
+select ai.set_view_description('public.hicks', 'description for hicks');
+select ai.set_column_description('public.hicks', 'id',  'description for hicks.id');
+select ai.set_column_description('public.hicks', 'foo', 'description for hicks.foo');
+select ai.set_column_description('public.hicks', 'bar', 'description for hicks.bar');
+
+create function public.hudson(x int) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('public.hudson'::regproc, 'description for hudson(int)');
+
+create function public.hudson(x int, y int) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('public.hudson(int, int)', 'description for hudson(int, int)');
+
+create table bishop.burke
+( id int not null primary key
+, foo text
+, bar text
+, baz bool
+);
+select ai.set_table_description('bishop.burke', 'description for bishop.burke');
+select ai.set_column_description('bishop.burke', 'id', 'description for bishop.burke.id');
+select ai.set_column_description('bishop.burke', 'foo', 'description for bishop.burke.foo');
+select ai.set_column_description('bishop.burke', 'bar', 'description for bishop.burke.bar');
+
+create function bishop.gorman(z bool) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('bishop.gorman(bool)', 'description for bishop.gorman(bool)');
+
+

--- a/projects/extension/tests/text_to_sql/init.sql
+++ b/projects/extension/tests/text_to_sql/init.sql
@@ -1,0 +1,66 @@
+
+-- TODO: remove feature flag
+select set_config('ai.enable_feature_flag_text_to_sql', 'true', false);
+create extension if not exists ai cascade;
+
+create schema billy;
+
+create table public.predator
+( id int not null primary key
+, foo text not null
+, bar timestamptz not null default now()
+);
+select ai.set_table_description ('public.predator', 'description for predator');
+select ai.set_column_description('public.predator', 'id', 'description for predator.id');
+select ai.set_column_description('public.predator', 'foo', 'description for predator.foo');
+select ai.set_column_description('public.predator', 'bar', 'description for predator.bar');
+
+create table billy.dillon
+( id int not null primary key
+, foo text not null
+, bar timestamptz not null default now()
+);
+select ai.set_table_description('billy.dillon', 'description for billy.dillon');
+select ai.set_column_description('billy.dillon', 'id', 'description for billy.dillon.id');
+select ai.set_column_description('billy.dillon', 'foo', 'description for billy.dillon.foo');
+select ai.set_column_description('billy.dillon', 'bar', 'description for billy.dillon.bar');
+
+create view public.hawkins as
+select * from billy.dillon;
+select ai.set_view_description('public.hawkins', 'description for hawkins');
+select ai.set_column_description('public.hawkins', 'id',  'description for hawkins.id');
+select ai.set_column_description('public.hawkins', 'foo', 'description for hawkins.foo');
+select ai.set_column_description('public.hawkins', 'bar', 'description for hawkins.bar');
+
+create function public.dutch(x int) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('public.dutch'::regproc, 'description for dutch(int)');
+
+create function public.dutch(x int, y int) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('public.dutch(int, int)', 'description for dutch(int, int)');
+
+create table billy.poncho
+( id int not null primary key 
+, foo text
+, bar text
+, baz bool
+);
+select ai.set_table_description('billy.poncho', 'description for billy.poncho');
+select ai.set_column_description('billy.poncho', 'id', 'description for billy.poncho.id');
+select ai.set_column_description('billy.poncho', 'foo', 'description for billy.poncho.foo');
+select ai.set_column_description('billy.poncho', 'bar', 'description for billy.poncho.bar');
+
+create function billy.mac(z bool) returns int
+as $func$
+    select 42
+$func$ language sql
+;
+select ai.set_function_description('billy.mac(bool)', 'description for billy.mac(bool)');
+

--- a/projects/extension/tests/text_to_sql/snapshot.sql
+++ b/projects/extension/tests/text_to_sql/snapshot.sql
@@ -1,0 +1,69 @@
+\pset pager off
+
+select version();
+
+-- Lists schemas
+\dn+
+-- Lists installed extensions.
+\dx
+-- all the objects belonging to each matching extension are listed.
+\dx+ ai
+-- Lists default access privilege settings.
+\ddp
+
+-- dynamically generate meta commands to describe schemas
+\! rm -f describe_schemas.sql
+select format('%s %s', c.c, s.s)
+from unnest(array
+[ 'public'
+, 'ai'
+]) s(s)
+cross join unnest(array
+[ '\dp+' -- Lists tables, views and sequences with their associated access privileges
+, '\ddp' -- Lists default access privilege settings. An entry is shown for each role (and schema, if applicable) for which the default privilege settings have been changed from the built-in defaults.
+]) c(c)
+order by c.c, s.s
+\g (tuples_only=on format=csv) describe_schemas.sql
+\i describe_schemas.sql
+
+-- dynamically generate meta commands to describe objects in the schemas
+\! rm -f describe_objects.sql
+select format('%s %s', c.c, s.s)
+from unnest(array
+[ 'public.*'
+, 'ai.*'
+]) s(s)
+cross join unnest(array
+[ '\d+' -- Describe each relation
+, '\df+' -- Describe functions
+, '\dp+' -- Lists tables, views and sequences with their associated access privileges.
+, '\di' -- Describe indexes
+, '\do' -- Lists operators with their operand and result types
+, '\dT' -- Lists data types.
+]) c(c)
+order by c.c, s.s
+\g (tuples_only=on format=csv) describe_objects.sql
+\i describe_objects.sql
+
+-- snapshot the data from all the tables and views
+select
+    format($$select '%I.%I' as table_snapshot;$$, n.nspname, k.relname),
+    case
+        -- we don't care about comparing the applied_at_version and applied_at columns of the migration table
+        when n.nspname = 'ai'::name and k.relname = 'migration'::name
+            then 'select name, body from ai.migration order by name, body;'
+        when n.nspname = 'ai'::name and k.relname = 'feature_flag'::name
+            then 'select name, applied_at_version from ai.migration order by name;'
+        when n.nspname = 'ai'::name and k.relname = 'description'::name
+            then 'select objtype, objnames, objargs, description from ai.description order by 1, 2, 3'
+        else format('select * from %I.%I tbl order by tbl;', n.nspname, k.relname)
+    end
+from pg_namespace n
+inner join pg_class k on (n.oid = k.relnamespace)
+where k.relkind in ('r', 'p', 'v')
+and n.nspname in
+( 'public'
+, 'ai'
+)
+order by n.nspname, k.relname
+\gexec

--- a/projects/extension/tests/text_to_sql/test_dump_restore.py
+++ b/projects/extension/tests/text_to_sql/test_dump_restore.py
@@ -1,0 +1,182 @@
+import os
+import subprocess
+from pathlib import Path
+
+import psycopg
+import pytest
+
+# skip tests in this module if disabled
+enable_text_to_sql_tests = os.getenv("ENABLE_TEXT_TO_SQL_TESTS")
+if enable_text_to_sql_tests == "0":
+    pytest.skip(allow_module_level=True)
+
+
+USER = "billy"  # NOT a superuser
+SRC_DB = "text_to_sql_src"
+DST_DB = "text_to_sql_dst"
+
+
+def db_url(user: str, dbname: str) -> str:
+    return f"postgres://{user}@127.0.0.1:5432/{dbname}"
+
+
+def where_am_i() -> str:
+    if "WHERE_AM_I" in os.environ and os.environ["WHERE_AM_I"] == "docker":
+        return "docker"
+    return "host"
+
+
+def docker_dir() -> str:
+    return "/pgai/tests/text_to_sql"
+
+
+def host_dir() -> Path:
+    return Path(__file__).parent.absolute()
+
+
+def create_user(user: str) -> None:
+    with psycopg.connect(
+        db_url(user="postgres", dbname="postgres"), autocommit=True
+    ) as con:
+        with con.cursor() as cur:
+            cur.execute(
+                """
+                select count(*) > 0
+                from pg_catalog.pg_roles
+                where rolname = %s
+            """,
+                (user,),
+            )
+            exists: bool = cur.fetchone()[0]
+            if not exists:
+                cur.execute(f"create user {user}")  # NOT a superuser
+
+
+def create_database(dbname: str) -> None:
+    with psycopg.connect(
+        db_url(user="postgres", dbname="postgres"), autocommit=True
+    ) as con:
+        with con.cursor() as cur:
+            cur.execute(f"drop database if exists {dbname} with (force)")
+            cur.execute(f"create database {dbname} with owner {USER}")
+
+
+def dump_db() -> None:
+    host_dir().joinpath("dump.sql").unlink(missing_ok=True)
+    cmd = " ".join(
+        [
+            "pg_dump -Fp --no-comments",
+            f'''-d "{db_url(USER, SRC_DB)}"''',
+            f"""-f {docker_dir()}/dump.sql""",
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def restore_db() -> None:
+    cmd = " ".join(
+        [
+            "psql",
+            f'''-d "{db_url(USER, DST_DB)}"''',
+            "-v VERBOSITY=verbose",
+            f"-f {docker_dir()}/dump.sql",
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def snapshot_db(dbname: str) -> None:
+    host_dir().joinpath(f"{dbname}.snapshot").unlink(missing_ok=True)
+    cmd = " ".join(
+        [
+            "psql",
+            f'''-d "{db_url("postgres", dbname)}"''',
+            "-v ON_ERROR_STOP=1",
+            "-X",
+            f"-o {docker_dir()}/{dbname}.snapshot",
+            f"-f {docker_dir()}/snapshot.sql",
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def init_src() -> None:
+    cmd = " ".join(
+        [
+            "psql",
+            f'''-d "{db_url(USER, SRC_DB)}"''',
+            "-v ON_ERROR_STOP=1",
+            f"-f {docker_dir()}/init.sql",
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def read_file(filename: str) -> str:
+    with open(filename, "r") as f:
+        return f.read()
+
+
+def extra(dbname: str) -> None:
+    cmd = " ".join(
+        [
+            "psql",
+            f'''-d "{db_url(USER, dbname)}"''',
+            "-v ON_ERROR_STOP=1",
+            f"-f {docker_dir()}/extra.sql",
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def post_restore() -> None:
+    with psycopg.connect(db_url(user=USER, dbname=DST_DB)) as con:
+        with con.cursor() as cur:
+            cur.execute("select ai.post_restore()")
+
+
+def check_mapping() -> bool:
+    with psycopg.connect(db_url(user=USER, dbname=DST_DB)) as con:
+        with con.cursor() as cur:
+            cur.execute("""
+                select
+                  count(*) =
+                  count(*) filter (where (d.objtype, d.objnames, d.objargs) = (x."type", x.object_names, x.object_args))
+                from ai.description d
+                cross join lateral pg_catalog.pg_identify_object_as_address
+                ( d.classid
+                , d.objid
+                , d.objsubid
+                ) x
+            """)
+            return cur.fetchone()[0]
+
+
+def test_dump_restore():
+    create_user(USER)
+    create_database(SRC_DB)
+    create_database(DST_DB)
+    init_src()
+    dump_db()
+    extra(SRC_DB)  # add extra descriptions AFTER dump so snapshots match
+    snapshot_db(SRC_DB)
+    extra(DST_DB)  # add extra descriptions BEFORE restore to make sure that works
+    restore_db()
+    post_restore()
+    snapshot_db(DST_DB)
+    src = read_file(str(host_dir().joinpath(f"{SRC_DB}.snapshot")))
+    dst = read_file(str(host_dir().joinpath(f"{DST_DB}.snapshot")))
+    assert dst == src
+    assert (
+        check_mapping() is True
+    )  # ensure that all the oids match the names after the restore

--- a/projects/extension/tests/text_to_sql/test_text_to_sql.py
+++ b/projects/extension/tests/text_to_sql/test_text_to_sql.py
@@ -1,0 +1,220 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import psycopg
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_up_test_db() -> None:
+    # create a test user and test database owned by the test user
+    with psycopg.connect(
+        "postgres://postgres@127.0.0.1:5432/postgres", autocommit=True
+    ) as con:
+        with con.cursor() as cur:
+            cur.execute("drop database if exists text_to_sql with (force)")
+            cur.execute("create database text_to_sql owner test")
+    # use the test user to create the extension in the text_to_sql database
+    with psycopg.connect("postgres://test@127.0.0.1:5432/text_to_sql") as con:
+        with con.cursor() as cur:
+            # turn on the feature flag for text_to_sql
+            cur.execute(
+                "select set_config('ai.enable_feature_flag_text_to_sql', 'true', false)"
+            )
+            cur.execute("create extension ai cascade")
+
+
+def db_url(user: str) -> str:
+    return f"postgres://{user}@127.0.0.1:5432/text_to_sql"
+
+
+def where_am_i() -> str:
+    if "WHERE_AM_I" in os.environ and os.environ["WHERE_AM_I"] == "docker":
+        return "docker"
+    return "host"
+
+
+def docker_dir() -> str:
+    return "/pgai/tests/text_to_sql"
+
+
+def host_dir() -> Path:
+    return Path(__file__).parent.absolute()
+
+
+def snapshot_descriptions(name: str) -> None:
+    host_dir().joinpath(f"{name}.actual").unlink(missing_ok=True)
+    cmd = " ".join(
+        [
+            "psql",
+            f'''-d "{db_url("test")}"''',
+            "-v ON_ERROR_STOP=1",
+            "-X",
+            f"-o {docker_dir()}/{name}.actual",
+            '-c "select objtype, objnames, objargs, description from ai.description order by 1,2,3"',
+        ]
+    )
+    if where_am_i() != "docker":
+        cmd = f"docker exec -w {docker_dir()} pgai-ext {cmd}"
+    subprocess.run(cmd, check=True, shell=True, env=os.environ, cwd=str(host_dir()))
+
+
+def file_contents(name: str) -> str:
+    return host_dir().joinpath(f"{name}").read_text()
+
+
+def test_description():
+    with psycopg.connect(db_url("test")) as con:
+        with con.cursor() as cur:
+            cur.execute("""
+            create table bob
+            ( id int not null primary key
+            , foo text not null
+            , bar timestamptz not null default now()
+            );
+
+            create view bobby as
+            select * from bob;
+
+            create function life(x int) returns int
+            as $func$select 42$func$ language sql;
+            """)
+
+            cur.execute("""
+            -- table
+            select ai.set_table_description('bob', 'this is a comment about the bob table');
+            select ai.set_column_description('bob', 'id', 'this is a comment about the id column');
+            select ai.set_column_description('bob', 'foo', 'this is a comment about the foo column');
+            select ai.set_column_description('bob', 'bar', 'this is a comment about the bar column');
+
+            -- view
+            select ai.set_view_description('bobby', 'this is a comment about the bob table');
+            select ai.set_column_description('bobby', 'id', 'this is a comment about the id column');
+            select ai.set_column_description('bobby', 'foo', 'this is a comment about the foo column');
+            select ai.set_column_description('bobby', 'bar', 'this is a comment about the bar column');
+
+            -- function
+            select ai.set_function_description('life'::regproc, 'this is a comment about the life function');
+            """)
+            con.commit()
+            snapshot_descriptions("0")
+            actual = file_contents("0.actual")
+            expected = file_contents("0.expected")
+            assert actual == expected
+
+            # change descriptions
+            cur.execute(
+                "select ai.set_table_description('bob', 'this is a BETTER comment about the bob table')"
+            )
+            cur.execute(
+                "select ai.set_column_description('bobby', 'id', 'this is a BETTER comment about the id column')"
+            )
+            cur.execute(
+                """
+                select ai.set_function_description
+                ( 'life'::regproc
+                , 'this is a BETTER comment about the life function'
+                )
+                """
+            )
+            con.commit()
+            snapshot_descriptions("1")
+            actual = file_contents("1.actual")
+            expected = file_contents("1.expected")
+            assert actual == expected
+
+            # rename function
+            cur.execute("alter function life(int) rename to death")
+            con.commit()
+            snapshot_descriptions("2")
+            actual = file_contents("2.actual")
+            expected = file_contents("2.expected")
+            assert actual == expected
+
+            # rename table column
+            cur.execute("alter table bob rename column foo to baz")
+            con.commit()
+            snapshot_descriptions("3")
+            actual = file_contents("3.actual")
+            expected = file_contents("3.expected")
+            assert actual == expected
+
+            # rename view
+            cur.execute("alter view bobby rename to frederick")
+            con.commit()
+            snapshot_descriptions("4")
+            actual = file_contents("4.actual")
+            expected = file_contents("4.expected")
+            assert actual == expected
+
+            # drop view
+            cur.execute("drop view frederick")
+            con.commit()
+            snapshot_descriptions("5")
+            actual = file_contents("5.actual")
+            expected = file_contents("5.expected")
+            assert actual == expected
+
+            # drop table column
+            cur.execute("alter table bob drop column baz")
+            con.commit()
+            snapshot_descriptions("6")
+            actual = file_contents("6.actual")
+            expected = file_contents("6.expected")
+            assert actual == expected
+
+            # alter function set schema
+            cur.execute("create schema maria")
+            cur.execute("alter function death set schema maria")
+            con.commit()
+            snapshot_descriptions("7")
+            actual = file_contents("7.actual")
+            expected = file_contents("7.expected")
+            assert actual == expected
+
+            # alter table set schema
+            cur.execute("alter table bob set schema maria")
+            con.commit()
+            snapshot_descriptions("8")
+            actual = file_contents("8.actual")
+            expected = file_contents("8.expected")
+            assert actual == expected
+
+            # test overloaded function names
+            cur.execute("""
+            create function maria.death(x int, y int) returns int
+            as $func$select 42$func$ language sql;
+            """)
+            cur.execute(
+                "select ai.set_function_description('maria.death(int, int)', 'overloaded')"
+            )
+            con.commit()
+            snapshot_descriptions("9")
+            actual = file_contents("9.actual")
+            expected = file_contents("9.expected")
+            assert actual == expected
+
+            # drop function
+            cur.execute("drop function maria.death(int)")
+            con.commit()
+            snapshot_descriptions("10")
+            actual = file_contents("10.actual")
+            expected = file_contents("10.expected")
+            assert actual == expected
+
+            # drop table
+            cur.execute("drop table maria.bob")
+            con.commit()
+            snapshot_descriptions("11")
+            actual = file_contents("11.actual")
+            expected = file_contents("11.expected")
+            assert actual == expected
+
+            # drop schema cascade
+            cur.execute("drop schema maria cascade")
+            con.commit()
+            snapshot_descriptions("12")
+            actual = file_contents("12.actual")
+            expected = file_contents("12.expected")
+            assert actual == expected


### PR DESCRIPTION
- adds an `ai.description` table for semantic descriptions of database objects
- "set description" functions for tables, views, columns, functions
- event triggers to keep the `ai.description` up-to-date in the face of DDL operations
- event trigger tests
- `ai.post_restore` function to true up oids after a dump/restore
- dump/restore test