### PR TITLE
chore: enable extension tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ permissions:
 
 jobs:
   build-and-test-extension:
+    services:
+      ollama:
+        image: ollama/ollama:latest
+        ports:
+          - 11434:11434
+
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,10 +55,32 @@ jobs:
         run: docker exec pgai-ext just install
 
       - name: Run test server
-        run: docker exec -d pgai-ext just test-server
+        run: docker exec -d
+          -e OPENAI_API_KEY
+          -e ANTHROPIC_API_KEY
+          -e COHERE_API_KEY
+          -e VOYAGE_API_KEY
+          pgai-ext just test-server
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
 
       - name: Run tests
-        run: docker exec pgai-ext just test
+        run: docker exec
+          -e OPENAI_API_KEY
+          -e ANTHROPIC_API_KEY
+          -e COHERE_API_KEY
+          -e VOYAGE_API_KEY
+          -e OLLAMA_HOST
+          pgai-ext just test
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+          VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+          OLLAMA_HOST: http://localhost:11434
 
       - name: Stop and remove Docker container
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,11 +139,6 @@ To set up the tests:
 1. In a [.env](https://saurabh-kumar.com/python-dotenv/) file, use the following flags to enable/disable test suites
     ```text
     # enable/disable tests
-    ENABLE_OPENAI_TESTS=1
-    ENABLE_OLLAMA_TESTS=1
-    ENABLE_ANTHROPIC_TESTS=1
-    ENABLE_COHERE_TESTS=1
-    ENABLE_VOYAGEAI_TESTS=1
     ENABLE_VECTORIZER_TESTS=1
     ENABLE_DUMP_RESTORE_TESTS=1
     ENABLE_PRIVILEGES_TESTS=1
@@ -153,13 +148,17 @@ To set up the tests:
 
 2. Some tests require extra environment variables to be added to the .env file
    - **OpenAI**:
-      - OPENAI_API_KEY - an [OpenAI API Key](https://platform.openai.com/api-keys) for OpenAI unit testing.
+      - `OPENAI_API_KEY` - an [OpenAI API Key](https://platform.openai.com/api-keys) for OpenAI unit testing.
    - **Ollama**:
-      - OLLAMA_HOST - the URL to the Ollama instance to use for testing. For example, `http://host.docker.internal:11434`.
+      - `OLLAMA_HOST` - the URL to the Ollama instance to use for testing. For example, `http://host.docker.internal:11434`.
    - **Anthropic**:
-      - ANTHROPIC_API_KEY - an [Anthropic API Key](https://docs.anthropic.com/en/docs/quickstart#set-your-api-key) for Anthropic unit testing.
+      - `ANTHROPIC_API_KEY` - an [Anthropic API Key](https://docs.anthropic.com/en/docs/quickstart#set-your-api-key) for Anthropic unit testing.
    - **Cohere**:
-      - COHERE_API_KEY - a [Cohere API Key](https://docs.cohere.com/docs/rate-limits) for Cohere unit testing.
+      - `COHERE_API_KEY` - a [Cohere API Key](https://docs.cohere.com/docs/rate-limits) for Cohere unit testing.
+   - **Voyage**:
+      - `VOYAGE_API_KEY` - a [Voyage API Key](https://voyageai.com) for Voyage unit testing.
+
+   Providing these keys automatically enables the corresponding tests.
 
 
 ### The pgai extension architecture

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -590,7 +590,13 @@ def where_am_i() -> str:
 
 def test_server() -> None:
     if where_am_i() == "host":
-        cmd = "docker exec -it -w /pgai/tests/vectorizer pgai-ext fastapi dev server.py"
+        cmd = """docker exec \
+            -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+            -e ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} \
+            -e COHERE_API_KEY=${COHERE_API_KEY} \
+            -e VOYAGE_API_KEY=${VOYAGE_API_KEY} \
+            -it -w /pgai/tests/vectorizer pgai-ext fastapi dev server.py
+            """
         subprocess.run(cmd, shell=True, check=True, env=os.environ, cwd=ext_dir())
     else:
         cmd = "fastapi dev server.py"

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -648,7 +648,7 @@ def docker_build() -> None:
 def docker_run() -> None:
     cmd = " ".join(
         [
-            "docker run -d --name pgai-ext -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust",
+            "docker run -d --name pgai-ext --network host -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust",
             f"--mount type=bind,src={ext_dir()},dst=/pgai",
             "-e TEST_ENV_SECRET=super_secret",
             "pgai-ext",

--- a/projects/extension/tests/test_anthropic.py
+++ b/projects/extension/tests/test_anthropic.py
@@ -5,7 +5,7 @@ import pytest
 
 
 # skip tests in this module if disabled
-enable_anthropic_tests = os.getenv("ENABLE_ANTHROPIC_TESTS")
+enable_anthropic_tests = os.getenv("ANTHROPIC_API_KEY")
 if not enable_anthropic_tests or enable_anthropic_tests == "0":
     pytest.skip(allow_module_level=True)
 

--- a/projects/extension/tests/test_cohere.py
+++ b/projects/extension/tests/test_cohere.py
@@ -5,7 +5,7 @@ import pytest
 
 
 # skip tests in this module if disabled
-enable_cohere_tests = os.getenv("ENABLE_COHERE_TESTS")
+enable_cohere_tests = os.getenv("COHERE_API_KEY")
 if not enable_cohere_tests or enable_cohere_tests == "0":
     pytest.skip(allow_module_level=True)
 

--- a/projects/extension/tests/test_ollama.py
+++ b/projects/extension/tests/test_ollama.py
@@ -47,7 +47,7 @@ def ensure_models(ollama_host):
     Ensure required models are downloaded before running tests.
     This fixture runs automatically at the start of the test session.
     """
-    required_models = ["llama3", "llava:7b"]
+    required_models = ["llama3.2:1b", "smollm:135m"]
     for model in required_models:
         wait_for_model_download(ollama_host, model)
 
@@ -95,7 +95,7 @@ def test_ollama_embed(cur, ollama_host):
         select vector_dims
         (
             ai.ollama_embed
-            ( 'llama3'
+            ( 'llama3.2:1b'
             , 'the purple elephant sits on a red mushroom'
             , host=>%s
             )
@@ -104,7 +104,7 @@ def test_ollama_embed(cur, ollama_host):
         (ollama_host,),
     )
     actual = cur.fetchone()[0]
-    assert actual == 4096
+    assert actual == 2048
 
 
 def test_ollama_embed_no_host(cur_with_ollama_host):
@@ -112,13 +112,13 @@ def test_ollama_embed_no_host(cur_with_ollama_host):
         select vector_dims
         (
             ai.ollama_embed
-            ( 'llama3'
+            ( 'llama3.2:1b'
             , 'the purple elephant sits on a red mushroom'
             )
         )
     """)
     actual = cur_with_ollama_host.fetchone()[0]
-    assert actual == 4096
+    assert actual == 2048
 
 
 def test_ollama_embed_via_openai(cur, ollama_host):
@@ -127,7 +127,7 @@ def test_ollama_embed_via_openai(cur, ollama_host):
         select vector_dims
         (
             ai.openai_embed
-            ( 'llama3'
+            ( 'llama3.2:1b'
             , 'the purple elephant sits on a red mushroom'
             , api_key=>'this is a garbage api key'
             , base_url=>concat(%s::text, '/v1/')
@@ -137,14 +137,14 @@ def test_ollama_embed_via_openai(cur, ollama_host):
         (ollama_host,),
     )
     actual = cur.fetchone()[0]
-    assert actual == 4096
+    assert actual == 2048
 
 
 def test_ollama_generate(cur, ollama_host):
     cur.execute(
         """
         select ai.ollama_generate
-        ( 'llama3'
+        ( 'llama3.2:1b'
         , 'what is the typical weather like in Alabama in June'
         , system_prompt=>'you are a helpful assistant'
         , host=>%s
@@ -163,7 +163,7 @@ def test_ollama_generate(cur, ollama_host):
 def test_ollama_generate_no_host(cur_with_ollama_host):
     cur_with_ollama_host.execute("""
         select ai.ollama_generate
-        ( 'llama3'
+        ( 'llama3.2:1b'
         , 'what is the typical weather like in Alabama in June'
         , system_prompt=>'you are a helpful assistant'
         , embedding_options=> jsonb_build_object
@@ -179,7 +179,7 @@ def test_ollama_generate_no_host(cur_with_ollama_host):
 def test_ollama_image(cur_with_ollama_host):
     cur_with_ollama_host.execute("""
         select ai.ollama_generate
-        ( 'llava:7b'
+        ( 'smollm:135m'
         , 'Please describe this image.'
         , images=> array[pg_read_binary_file('/pgai/tests/postgresql-vs-pinecone.jpg')]
         , system_prompt=>'you are a helpful assistant'
@@ -197,7 +197,7 @@ def test_ollama_chat_complete(cur, ollama_host):
     cur.execute(
         """
         select ai.ollama_chat_complete
-        ( 'llama3'
+        ( 'llama3.2:1b'
           , jsonb_build_array
             ( jsonb_build_object('role', 'system', 'content', 'you are a helpful assistant')
             , jsonb_build_object('role', 'user', 'content', 'what is the typical weather like in Alabama in June')
@@ -223,7 +223,7 @@ def test_ollama_chat_complete(cur, ollama_host):
 def test_ollama_chat_complete_no_host(cur_with_ollama_host):
     cur_with_ollama_host.execute("""
         select ai.ollama_chat_complete
-        ( 'llama3'
+        ( 'llama3.2:1b'
           , jsonb_build_array
             ( jsonb_build_object('role', 'system', 'content', 'you are a helpful assistant')
             , jsonb_build_object('role', 'user', 'content', 'what is the typical weather like in Alabama in June')
@@ -246,7 +246,7 @@ def test_ollama_chat_complete_no_host(cur_with_ollama_host):
 def test_ollama_chat_complete_image(cur_with_ollama_host):
     cur_with_ollama_host.execute("""
         select ai.ollama_chat_complete
-        ( 'llava:7b'
+        ( 'smollm:135m'
         , jsonb_build_array
           ( jsonb_build_object
             ( 'role', 'user'
@@ -267,7 +267,7 @@ def test_ollama_chat_complete_image(cur_with_ollama_host):
 def test_ollama_ps(cur, ollama_host):
     cur.execute(
         """
-        select count(*) filter (where "name" = 'llava:7b') as actual
+        select count(*) filter (where "name" = 'smollm:135m') as actual
         from ai.ollama_ps(host=>%s)
     """,
         (ollama_host,),
@@ -278,7 +278,7 @@ def test_ollama_ps(cur, ollama_host):
 
 def test_ollama_ps_no_host(cur_with_ollama_host):
     cur_with_ollama_host.execute("""
-        select count(*) filter (where "name" = 'llava:7b') as actual
+        select count(*) filter (where "name" = 'smollm:135m') as actual
         from ai.ollama_ps()
     """)
     actual = cur_with_ollama_host.fetchone()[0]

--- a/projects/extension/tests/test_openai.py
+++ b/projects/extension/tests/test_openai.py
@@ -5,7 +5,7 @@ import pytest
 
 
 # skip tests in this module if disabled
-enable_openai_tests = os.getenv("ENABLE_OPENAI_TESTS")
+enable_openai_tests = os.getenv("OPENAI_API_KEY")
 if not enable_openai_tests or enable_openai_tests == "0":
     pytest.skip(allow_module_level=True)
 

--- a/projects/extension/tests/test_voyageai.py
+++ b/projects/extension/tests/test_voyageai.py
@@ -5,7 +5,7 @@ import pytest
 
 
 # skip tests in this module if disabled
-enable_voyageai_tests = os.getenv("ENABLE_VOYAGEAI_TESTS")
+enable_voyageai_tests = os.getenv("VOYAGE_API_KEY")
 if not enable_voyageai_tests or enable_voyageai_tests == "0":
     pytest.skip(allow_module_level=True)
 


### PR DESCRIPTION
I replaced the ENABLE_ flags for each API provider with simply checking if a key is present. I think this makes more sense so you don't have to provide both env vars?

I also added a download fixture to the ollama tests so that the necessary models are downloaded during the test runs. This is quite slow, but I guess we can add caching later.

Other than that this was quite straight forward. Only issue is that voyageai already hits rate limits with my free key now.