### PR TITLE
fix: host networking is not supported on mac

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import hashlib
+import platform
 import re
 import os
 import shutil
@@ -653,9 +654,13 @@ def docker_build() -> None:
 
 
 def docker_run() -> None:
+    networking = (
+        "--network host" if platform.system() == "Linux" else "-p 127.0.0.1:5432:5432"
+    )
     cmd = " ".join(
         [
-            "docker run -d --name pgai-ext --network host -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust",
+            "docker run -d --name pgai-ext --hostname pgai-ext -e POSTGRES_HOST_AUTH_METHOD=trust",
+            networking,
             f"--mount type=bind,src={ext_dir()},dst=/pgai",
             "-e TEST_ENV_SECRET=super_secret",
             "pgai-ext",


### PR DESCRIPTION
The `--network host` flag is not supported on macos and Windows (unless a beta flag is enabled). Let's make the dev environment work out-of-the-box. If we turn on `--network host`, the `-p 127.0.0.1:5432:5432` flag is ignored, and then you cannot connect to the database from outside the container. This breaks the dev/test experience for non-linux users.

>The host networking driver only works on Linux hosts, but is available as a beta feature on Docker Desktop version 4.29 and later for Mac, Windows, and Linux. To enable this feature, navigate to the Resources tab in Settings, and then under Network select Enable host networking.

![image](https://github.com/user-attachments/assets/715778a7-4593-438f-a5e7-5e1b2d807697)

https://docs.docker.com/engine/network/tutorials/host/