### PR TITLE
docs: use named volumes in quickstart guides

### DIFF
--- a/docs/vectorizer-quick-start-openai.md
+++ b/docs/vectorizer-quick-start-openai.md
@@ -27,12 +27,14 @@ On your local machine:
         ports:
           - "5432:5432"
         volumes:
-          - ./data:/home/postgres/pgdata/data
+          - data:/home/postgres/pgdata/data
       vectorizer-worker:
         image: timescale/pgai-vectorizer-worker:v0.2.1
         environment:
           PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
           OPENAI_API_KEY: <your-api-key>
+    volumes:
+      data:
     ```
 
 1. **Tune the developer image for your AI provider**

--- a/docs/vectorizer-quick-start-voyage.md
+++ b/docs/vectorizer-quick-start-voyage.md
@@ -25,13 +25,15 @@ On your local machine:
        ports:
          - "5432:5432"
        volumes:
-         - ./data:/home/postgres/pgdata/data
+         - data:/home/postgres/pgdata/data
      vectorizer-worker:
        image: timescale/pgai-vectorizer-worker:v0.3.0
        environment:
          PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
          VOYAGE_API_KEY: your-api-key
        command: [ "--poll-interval", "5s" ]
+   volumes:
+     data:
     ```
 
 1. **Start the services**

--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -25,7 +25,7 @@ On your local machine:
        ports:
          - "5432:5432"
        volumes:
-         - ./data:/home/postgres/pgdata/data
+         - data:/home/postgres/pgdata/data
      vectorizer-worker:
        image: timescale/pgai-vectorizer-worker:v0.2.1
        environment:
@@ -34,6 +34,8 @@ On your local machine:
        command: [ "--poll-interval", "5s" ]
      ollama:
        image: ollama/ollama
+   volumes:
+     data:
     ```
 
 1. **Start the services**

--- a/docs/vectorizer-worker.md
+++ b/docs/vectorizer-worker.md
@@ -63,7 +63,7 @@ On your local machine:
         ports:
           - "5432:5432"
         volumes:
-          - ./data:/var/lib/postgresql/data
+          - data:/var/lib/postgresql/data
       vectorizer-worker:
         image: timescale/pgai-vectorizer-worker:v0.2.1
         environment:
@@ -72,6 +72,8 @@ On your local machine:
         command: [ "--poll-interval", "5s" ]
       ollama:
         image: ollama/ollama
+    volumes:
+      data:
     ```
 
 1. **Start the services locally**


### PR DESCRIPTION
In aabbc681 we corrected the volume path for the database data volume. If the 'data' directly does not already exist then this fails on both Mac and Linux because the directory is created as root and the postgres user in the container doesn't have permissions to initdb.

Switching to a named volume solves these problems, and prevents us polluting `pwd` with the data dir.