### PR TITLE
chore: fix broken pgai build by pinning hatchling

### DIFF
--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [project]

--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "pgai"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The build started failing with the following error message:

```
Checking ./dist/pgai-0.3.0-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,
         Version.
         Make sure the distribution includes the files where those fields are
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,
         2.0, 2.1, 2.2, 2.3.
```

This error comes from `twine check dist/*`. It is caused by the fact that `hatchling`, which we use to build wheels, released a new version which bumped the `Metadata-Version` field to `2.4`, and twine/pkginfo aren't able to process this version.

By pinning `hatchling` to 1.26.3, the previous release, we solve this immediate problem, and avoid new breakage from future hatchling releases.