### PR TITLE
chore: support uv in extension install, use for dev

### DIFF
--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -47,6 +47,7 @@ RUN set -e; \
 FROM base AS pgai-test-db
 ENV PG_MAJOR=${PG_MAJOR}
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip install uv==0.5.9
 WORKDIR /pgai
 COPY . .
 RUN just build install
@@ -58,17 +59,17 @@ FROM base
 ENV WHERE_AM_I=docker
 USER root
 
+RUN pip install --break-system-packages uv==0.5.9
+
 # install pgspot
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN set -eux; \
     git clone https://github.com/timescale/pgspot.git /build/pgspot; \
-    pip install /build/pgspot; \
+    uv pip install --system --break-system-packages /build/pgspot; \
     rm -rf /build/pgspot
 
 # install our test python dependencies
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 COPY requirements-test.txt /build/requirements-test.txt
-RUN pip install -r /build/requirements-test.txt
+RUN uv pip install --system --break-system-packages -r /build/requirements-test.txt
 RUN rm -r /build
 
 WORKDIR /pgai

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -451,9 +451,13 @@ def install_old_py_deps() -> None:
     old_reqs_file = ext_dir().joinpath("old_requirements.txt").resolve()
     if old_reqs_file.is_file():
         env = {k: v for k, v in os.environ.items()}
-        env["PIP_BREAK_SYSTEM_PACKAGES"] = "1"
+        cmd = (
+            f"pip3 install -v --compile --break-system-packages -r {old_reqs_file}"
+            if shutil.which("uv") is None
+            else f"uv pip install -v --compile --system --break-system-packages -r {old_reqs_file}"
+        )
         subprocess.run(
-            f"pip3 install -v --compile -r {old_reqs_file}",
+            cmd,
             shell=True,
             check=True,
             env=env,
@@ -482,8 +486,10 @@ def install_prior_py() -> None:
             env=os.environ,
         )
         tmp_src_dir = tmp_dir.joinpath("projects", "extension").resolve()
+        bin = "pip3" if shutil.which("uv") is None else "uv pip"
+        cmd = f'{bin} install -v --compile --target "{version_target_dir}" "{tmp_src_dir}"'
         subprocess.run(
-            f'pip3 install -v --compile -t "{version_target_dir}" "{tmp_src_dir}"',
+            cmd,
             check=True,
             shell=True,
             env=os.environ,
@@ -524,8 +530,10 @@ def install_py() -> None:
             "pgai-*.dist-info"
         ):  # delete package info if exists
             shutil.rmtree(d)
+        bin = "pip3" if shutil.which("uv") is None else "uv pip"
+        cmd = f'{bin} install -v --no-deps --compile --target "{version_target_dir}" "{ext_dir()}"'
         subprocess.run(
-            f'pip3 install -v --no-deps --compile -t "{version_target_dir}" "{ext_dir()}"',
+            cmd,
             check=True,
             shell=True,
             env=os.environ,
@@ -533,8 +541,12 @@ def install_py() -> None:
         )
     else:
         version_target_dir.mkdir(exist_ok=True)
+        bin = "pip3" if shutil.which("uv") is None else "uv pip"
+        cmd = (
+            f'{bin} install -v --compile --target "{version_target_dir}" "{ext_dir()}"'
+        )
         subprocess.run(
-            f'pip3 install -v --compile -t "{version_target_dir}" "{ext_dir()}"',
+            cmd,
             check=True,
             shell=True,
             env=os.environ,

--- a/projects/extension/requirements-test.txt
+++ b/projects/extension/requirements-test.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 fastapi==0.112.0
 fastapi-cli==0.0.5
 psycopg[binary]==3.2.1
+uv==0.5.9


### PR DESCRIPTION
We would like to support uv in an opt-in fashion. The `build.py install` now uses uv if it is available, otherwise falling back to pip. To use uv, we now install it in our dev containers.