### PR TITLE
fix: exclude python system packages for versioned extension

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -283,6 +283,13 @@ def build_idempotent_sql_file(input_file: Path) -> str:
         r = plpy.execute("select coalesce(pg_catalog.current_setting('ai.python_lib_dir', true), '{python_install_dir()}') as python_lib_dir")
         python_lib_dir = r[0]["python_lib_dir"]
         from pathlib import Path
+        import sys
+        import sysconfig
+        # Note: the "old" (pre-0.4.0) packages are installed as system-level python packages
+        # and take precedence over our extension-version specific packages.
+        # By removing the whole thing from the path we won't run into package conflicts.
+        if "purelib" in sysconfig.get_path_names() and sysconfig.get_path("purelib") in sys.path:
+            sys.path.remove(sysconfig.get_path("purelib"))
         python_lib_dir = Path(python_lib_dir).joinpath("{this_version()}")
         import site
         site.addsitedir(str(python_lib_dir))


### PR DESCRIPTION
We install the dependencies for an extension version in a specific path for that version alone. When one of our plpython3u functions is called, we set up the python path to include these dependencies.

For the very first extension releases, we didn't do it this way. Instead, the dependencies were installed into the system python's path. As a result, we were inadvertently using _both_ packages installed for the system python, and the packages installed for the specific extension version. When the same package is installed in both, the system python version is chosen first. This breaks Python's assumptions about dependency resolution, and can break installed packages.

This change removes the system python dependencies from the python path, so only the actual dependencies we wanted are available.