### PR TITLE
fix: deprecation warning on re.split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: "pip" # caching pip dependencies
 
       - name: Verify Docker installation
         run: |

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -83,7 +83,7 @@ def check_versions():
 
 
 def parse_version(version: str) -> tuple[int, int, int, str | None]:
-    parts = re.split(r"[.-]", version, 4)
+    parts = re.split(r"[.-]", version, maxsplit=4)
     return (
         int(parts[0]),
         int(parts[1]),


### PR DESCRIPTION
Running the script under Python 3.13, I get:

```
/Users/mpeveler/code/timescale/pgai/projects/extension/./build.py:86: DeprecationWarning: 'maxsplit' is passed as positional argument
  parts = re.split(r"[.-]", version, 4)
```

which this PR resolves. The deprecation warning was added in Python 3.13, where at some future version of Python, `maxsplit` will be required to be passed as a keyword-only argument.