### PR TITLE
chore: build latest image on push

### DIFF
--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches:
+      - main
+
+name: build-worker
+
+jobs:
+  build-worker:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: timescale/pgai-vectorizer-worker
+          labels: |
+            org.opencontainers.image.description=A worker for self-hosted pgai vectorizers
+            org.opencontainers.image.title=pgai-vectorizer-worker
+          tags:
+            type=raw,value=latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:projects/pgai"
+          push: true
+          tags: | 
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/docs/vectorizer-quick-start-openai.md
+++ b/docs/vectorizer-quick-start-openai.md
@@ -29,7 +29,7 @@ On your local machine:
         volumes:
           - data:/home/postgres/pgdata/data
       vectorizer-worker:
-        image: timescale/pgai-vectorizer-worker:v0.2.1
+        image: timescale/pgai-vectorizer-worker:latest
         environment:
           PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
           OPENAI_API_KEY: <your-api-key>

--- a/docs/vectorizer-quick-start-voyage.md
+++ b/docs/vectorizer-quick-start-voyage.md
@@ -27,7 +27,7 @@ On your local machine:
        volumes:
          - data:/home/postgres/pgdata/data
      vectorizer-worker:
-       image: timescale/pgai-vectorizer-worker:v0.3.0
+       image: timescale/pgai-vectorizer-worker:latest
        environment:
          PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
          VOYAGE_API_KEY: your-api-key

--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -27,7 +27,7 @@ On your local machine:
        volumes:
          - data:/home/postgres/pgdata/data
      vectorizer-worker:
-       image: timescale/pgai-vectorizer-worker:v0.2.1
+       image: timescale/pgai-vectorizer-worker:latest
        environment:
          PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
          OLLAMA_HOST: http://ollama:11434

--- a/docs/vectorizer-worker.md
+++ b/docs/vectorizer-worker.md
@@ -65,7 +65,7 @@ On your local machine:
         volumes:
           - data:/var/lib/postgresql/data
       vectorizer-worker:
-        image: timescale/pgai-vectorizer-worker:v0.2.1
+        image: timescale/pgai-vectorizer-worker:latest
         environment:
           PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
           OLLAMA_HOST: http://ollama:11434
@@ -75,6 +75,7 @@ On your local machine:
     volumes:
       data:
     ```
+   **Note**: we are using the `:latest` version of the vectorizer worker imager here. This is a dev build and built on each push. While we try to keep this image working and will fix issues asap, it is not recommended for production use. For that, please use a specific version tag.
 
 1. **Start the services locally**
    ```shell


### PR DESCRIPTION
The idea here:
- Keep `latest` always up-to-date with main (or call it `main`?)
- Don't break main if possible, fix it fast if it breaks (we've been doing that anyways)
- Refer to the new `latest` tag everywhere in the docs
- Mention that for production use people should use a specific version instead

Problems:
- What if the main version of the vectorizer worker becomes incompatible with the currently released pgai extension version? We don't have a `latest` in development timescale-ha image. Is this something we should plan for?