### PR TITLE
docs: remove openai mention, fix opclasses in hnsw index

### DIFF
--- a/docs/vectorizer-api-reference.md
+++ b/docs/vectorizer-api-reference.md
@@ -602,7 +602,7 @@ HNSW is suitable for in-memory datasets and scenarios where query speed is cruci
 ```sql
   SELECT ai.create_vectorizer(
       'blog_posts'::regclass,
-      indexing => ai.indexing_hnsw(min_rows => 50000, opclass => 'vector_l2_ops'),
+      indexing => ai.indexing_hnsw(min_rows => 50000, opclass => 'vector_l1_ops'),
       -- other parameters...
   );
 ```
@@ -614,10 +614,10 @@ HNSW is suitable for in-memory datasets and scenarios where query speed is cruci
 | Name | Type | Default             | Required | Description                                                                                                    |
 |------|------|---------------------|-|----------------------------------------------------------------------------------------------------------------|
 |min_rows| int  | 100000              |✖| The minimum number of rows before creating the index                                                           |
-|opclass| text  | `vector_cosine_ops` |✖| The operator class for the index. Possible values are:`vector_cosine_ops`, `vector_l2_ops`, or `vector_ip_ops` |
+|opclass| text  | `vector_cosine_ops` |✖| The operator class for the index. Possible values are:`vector_cosine_ops`, `vector_l1_ops`, or `vector_ip_ops` |
 |m| int  | -                   |✖| Advanced [HNSW parameters](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world)                   |
-|ef_construction| int  | -                   |✖|  Advanced [HNSW parameters](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world)                                                                                                              |
-| create_when_queue_empty| boolean | true |✖| Create the index only after all of the embeddings have been generated. |
+|ef_construction| int  | -                   |✖| Advanced [HNSW parameters](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world)                   |
+| create_when_queue_empty| boolean | true |✖| Create the index only after all of the embeddings have been generated.                                         |
 
 
 #### Returns

--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -5,7 +5,7 @@ If you prefer working with the OpenAI API instead of self-hosting models, you ca
 
 ## Setup a local development environment
 
-To set up a development environment for OpenAI, use a docker compose file that includes a:
+To set up a development environment, use a docker compose file that includes a:
 - Postgres deployment image with the TimescaleDB and pgai extensions installed
 - pgai vectorizer worker image
 - ollama image to host embedding and large language models


### PR DESCRIPTION
We actually don't allow l2 distance according to the code:
https://github.com/timescale/pgai/blob/main/projects/extension/sql/ai--0.6.0.sql#L2112 (although it would probably work if we'd change that)

The vectorizer quickstart is ollama focused on openai not sure how that snuck in there.