### PR TITLE
test: spawn the ollama container through testcontainers

### DIFF
--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -7,6 +7,7 @@ import tiktoken
 import vcr  # type:ignore
 from testcontainers.core.image import DockerImage  # type:ignore
 from testcontainers.postgres import PostgresContainer  # type:ignore
+from testcontainers.ollama import OllamaContainer  # type:ignore
 
 from pgai.vectorizer.vectorizer import TIKTOKEN_CACHE_DIR
 
@@ -70,3 +71,9 @@ def postgres_container():
         driver=None,
     ) as postgres:
         yield postgres
+
+@pytest.fixture(scope="session")
+def ollama_container():
+    with OllamaContainer(image="ollama/ollama:latest") as ollama:
+        yield ollama
+

--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -7,7 +7,6 @@ import tiktoken
 import vcr  # type:ignore
 from testcontainers.core.image import DockerImage  # type:ignore
 from testcontainers.postgres import PostgresContainer  # type:ignore
-from testcontainers.ollama import OllamaContainer  # type:ignore
 
 from pgai.vectorizer.vectorizer import TIKTOKEN_CACHE_DIR
 
@@ -71,9 +70,3 @@ def postgres_container():
         driver=None,
     ) as postgres:
         yield postgres
-
-@pytest.fixture(scope="session")
-def ollama_container():
-    with OllamaContainer(image="ollama/ollama:latest") as ollama:
-        yield ollama
-

--- a/projects/pgai/tests/vectorizer/test_vectorizer_cli.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer_cli.py
@@ -156,7 +156,10 @@ def ollama_connection_url():
         yield os.environ["OLLAMA_HOST"]
     else:
         with OllamaContainer(
-            image="ollama/ollama:latest", ollama_home=Path.home() / ".ollama"
+            image="ollama/ollama:latest",
+            # Passing the ollama_home lets us reuse models that have already
+            # been pulled to the `~/.ollama` path on the host machine.
+            ollama_home=Path.home() / ".ollama",
         ) as ollama:
             yield ollama.get_endpoint()
 


### PR DESCRIPTION
This PR spawns a new `ollama/ollama:latest` container through testcontainers when a test requires an ollama server to be up.

As a mechanism to override this behavior, the container won't be used if a `OLLAMA_HOST` env var is found, using the value of it instead.

Open to better alternatives.