### PR TITLE
fix: openai wrapping text-to-sql query in markdown

### DIFF
--- a/projects/extension/sql/idempotent/905-text-to-sql.sql
+++ b/projects/extension/sql/idempotent/905-text-to-sql.sql
@@ -427,6 +427,7 @@ begin
 You are an expert database developer and DBA specializing in PostgreSQL.
 You will be provided with context about a database model and a question to be answered.
 You respond with nothing but a SQL statement that addresses the question posed.
+You should not wrap the SQL statement in markdown.
 The SQL statement must be valid syntax for PostgreSQL.
 SQL features and functions that are built-in to PostgreSQL may be used.
 $txt$);


### PR DESCRIPTION
PR modifies the system prompt that's used for `text_to_sql` to include not wrapping the returned query in markdown as `ai.text_to_sql_openai` often would. With this change, I found that both `text_to_sql_anthropic` and `ai.text_to_sql_openai` just return the SQL query and nothing else.