### PR TITLE
ci: install all dependencies through just pgai install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,7 @@ jobs:
           python-version-file: "./projects/pgai/.python-version"
 
       - name: Install dependencies
-        working-directory: ./projects/pgai
-        run: uv sync --all-extras
+        run: just pgai install
 
       - name: Lint
         run: just pgai lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,23 +111,7 @@ jobs:
         with:
           python-version-file: "./projects/pgai/.python-version"
 
-      - name: Install dependencies
-        run: just pgai install
-
-      - name: Lint
-        run: just pgai lint
-
-      - name: Check Typing
-        run: just pgai type-check
-
-      - name: Check Formatting
-        run: just pgai format
-
-      - name: Run Tests
-        run: just pgai test
+      - name: CI pipeline. Install dependencies, run linters and formatters, execute tests and build the project", 
+        run: just pgai ci
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        
-
-      - name: Build the pgai distributable and check artifacts
-        run: just pgai build

--- a/projects/pgai/justfile
+++ b/projects/pgai/justfile
@@ -25,7 +25,7 @@ build:
 
 # Install the wheel package locally
 install:
-	@uv sync
+	@uv sync --all-extras
 
 # Remove the installed pgai package
 uninstall:

--- a/projects/pgai/justfile
+++ b/projects/pgai/justfile
@@ -51,7 +51,8 @@ type-check:
 format:
 	@uv run ruff format --diff ./
 
-ci: lint type-check format test build
+# CI pipeline. Runs all recipes needed for ensuring the code is ready to be integrated. Triggered by GH Actions
+ci: install lint type-check format test build
 
 # Build Docker image with version tag
 docker-build:


### PR DESCRIPTION
- Updated the `just pgai install` to include the `--all-extras` flag.
- Modified the command for installing dependencies in GH actions to use `just pgai install`.

