### PR TITLE
test: use psycopg over psycopg2 for sqlalchemy tests

### DIFF
--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -115,5 +115,4 @@ dev-dependencies = [
     "testcontainers==4.8.1",
     "build==1.2.2.post1",
     "twine==5.1.1",
-    "psycopg2==2.9.10",
 ]

--- a/projects/pgai/tests/vectorizer/extensions/conftest.py
+++ b/projects/pgai/tests/vectorizer/extensions/conftest.py
@@ -32,7 +32,7 @@ def initialized_engine(
     Returns:
         Engine: Configured SQLAlchemy engine
     """
-    engine = create_engine(postgres_container.get_connection_url())
+    engine = create_engine(postgres_container.get_connection_url(driver="psycopg"))
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS ai CASCADE;"))
         conn.commit()

--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -1241,7 +1241,6 @@ sqlalchemy = [
 dev = [
     { name = "build" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "psycopg2" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "python-dotenv" },
@@ -1275,7 +1274,6 @@ requires-dist = [
 dev = [
     { name = "build", specifier = "==1.2.2.post1" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.1" },
-    { name = "psycopg2", specifier = "==2.9.10" },
     { name = "pyright", specifier = "==1.1.385" },
     { name = "pytest", specifier = "==8.3.2" },
     { name = "python-dotenv", specifier = "==1.0.1" },
@@ -1525,20 +1523,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/dd/0ae42c64bf524d1fcf9bf861ab09d331e693ae00e527ba08131b2d3729a3/psycopg_binary-3.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4c84fcac8a3a3479ac14673095cc4e1fdba2935499f72c436785ac679bec0d1a", size = 3184097 },
     { url = "https://files.pythonhosted.org/packages/dd/f0/09329ebb0cd03e2ee5786fc9914ac904f4965b78627f15826f8258fde734/psycopg_binary-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:950fd666ec9e9fe6a8eeb2b5a8f17301790e518953730ad44d715b59ffdbc67f", size = 3228517 },
     { url = "https://files.pythonhosted.org/packages/60/2f/979228189adbeb59afce626f1e7c3bf73cc7ff94217099a2ddfd6fd132ff/psycopg_binary-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:334046a937bb086c36e2c6889fe327f9f29bfc085d678f70fac0b0618949f674", size = 2911959 },
-]
-
-[[package]]
-name = "psycopg2"
-version = "2.9.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/51/2007ea29e605957a17ac6357115d0c1a1b60c8c984951c19419b3474cdfd/psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11", size = 385672 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/a9/146b6bdc0d33539a359f5e134ee6dda9173fb8121c5b96af33fa299e50c4/psycopg2-2.9.10-cp310-cp310-win32.whl", hash = "sha256:5df2b672140f95adb453af93a7d669d7a7bf0a56bcd26f1502329166f4a61716", size = 1024527 },
-    { url = "https://files.pythonhosted.org/packages/47/50/c509e56f725fd2572b59b69bd964edaf064deebf1c896b2452f6b46fdfb3/psycopg2-2.9.10-cp310-cp310-win_amd64.whl", hash = "sha256:c6f7b8561225f9e711a9c47087388a97fdc948211c10a4bccbf0ba68ab7b3b5a", size = 1163735 },
-    { url = "https://files.pythonhosted.org/packages/20/a2/c51ca3e667c34e7852157b665e3d49418e68182081060231d514dd823225/psycopg2-2.9.10-cp311-cp311-win32.whl", hash = "sha256:47c4f9875125344f4c2b870e41b6aad585901318068acd01de93f3677a6522c2", size = 1024538 },
-    { url = "https://files.pythonhosted.org/packages/33/39/5a9a229bb5414abeb86e33b8fc8143ab0aecce5a7f698a53e31367d30caa/psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4", size = 1163736 },
-    { url = "https://files.pythonhosted.org/packages/3d/16/4623fad6076448df21c1a870c93a9774ad8a7b4dd1660223b59082dd8fec/psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067", size = 1025113 },
-    { url = "https://files.pythonhosted.org/packages/66/de/baed128ae0fc07460d9399d82e631ea31a1f171c0c4ae18f9808ac6759e3/psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e", size = 1163951 },
 ]
 
 [[package]]


### PR DESCRIPTION
PR replaces usage of `psycopg2` with `psycopg` for the sqlalchemy tests that were added in #265, as we already were installing `psycopg` for other tests, and that installing `psycopg2` can be a bit annoying for folks on macOS (see https://github.com/psycopg/psycopg2/issues/1200 as an example).