### PR TITLE
chore: register postgres_params custom pytest.mark

### DIFF
--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -64,6 +64,9 @@ pgai = "pgai.cli:cli"
 addopts = [
     "--import-mode=importlib",
 ]
+markers = [
+    "postgres_params: Parameters for the postgres_container fixture (e.g. `load_openai_key=False`)"
+]
 python_files = ["test_*.py"]
 
 [tool.pyright]


### PR DESCRIPTION
PR registers the custom `pytest.mark.postgres_params` mark (per [pytest docs](https://docs.pytest.org/en/stable/how-to/mark.html)) so that should no longer see the following warning when running the pgai tests:

```
=============================================== warnings summary ===============================================
tests/vectorizer/test_vectorizer_cli.py:320
  /Users/mpeveler/code/timescale/pgai/projects/pgai/tests/vectorizer/test_vectorizer_cli.py:320: PytestUnknownMarkWarning: Unknown pytest.mark.postgres_params - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.postgres_params(load_openai_key=False)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```