### PR TITLE
Default PG_BIN

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -385,7 +385,7 @@ def clean_sql() -> None:
 
 
 def postgres_bin_dir() -> Path:
-    bin_dir = os.getenv("PG_BIN")
+    bin_dir = os.getenv("PG_BIN", "/usr/bin")
     if bin_dir is not None and Path(bin_dir).is_dir():
         return Path(bin_dir).resolve()
     else:


### PR DESCRIPTION
If one runs this w/o just, then this variable won't necessarily be set in the environment and the code will fail This patch adds a default for the getenv call