### PR TITLE
feat: add just ext docker-start cmd

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,12 +120,18 @@ To make changes to pgai:
          just ext psql-shell
          ```
 
-1. Stop and delete the container:
+1. Stop and start the container:
 
    ```bash
    # Stop the container
    just ext docker-stop
-   # Delete the container
+   # Start the container
+   just ext docker-start
+
+1. Delete the container:
+
+   ```bash
+   # When stopped, delete the container
    just ext docker-rm
    ```
 

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -690,6 +690,12 @@ def docker_run() -> None:
     subprocess.run(cmd, shell=True, check=True, env=os.environ, text=True)
 
 
+def docker_start() -> None:
+    subprocess.run(
+        """docker start pgai-ext""", shell=True, check=True, env=os.environ, text=True
+    )
+
+
 def docker_stop() -> None:
     subprocess.run(
         """docker stop pgai-ext""", shell=True, check=True, env=os.environ, text=True
@@ -766,6 +772,8 @@ if __name__ == "__main__":
             docker_build()
         elif action == "docker-run":
             docker_run()
+        elif action == "docker-start":
+            docker_start()
         elif action == "docker-stop":
             docker_stop()
         elif action == "docker-rm":

--- a/projects/extension/justfile
+++ b/projects/extension/justfile
@@ -85,6 +85,9 @@ docker-build:
 docker-run:
 	@./build.py docker-run
 
+docker-start:
+	@./build.py docker-start
+
 docker-stop:
 	@./build.py docker-stop
 


### PR DESCRIPTION
PR adds a `just ext docker-start` cmd which mirrors the `just ext docker-stop` command. I've got a couple of projects that use postgres and all expose the `5432` port on the host, and so was using the `just ext docker-stop` when I switched projects, and was then annoyed when there wasn't a matching `just ext docker-start` command, and having to result to bare docker commands.