### PR TITLE
fix: handle 'null' value in chunking 'chunk_column'

### DIFF
--- a/projects/pgai/pgai/vectorizer/chunking.py
+++ b/projects/pgai/pgai/vectorizer/chunking.py
@@ -80,7 +80,8 @@ class LangChainCharacterTextSplitter(BaseModel, Chunker):
         Returns:
             list[str]: A list of chunked strings.
         """
-        return self._chunker.split_text(item[self.chunk_column])
+        text = item[self.chunk_column] or ""
+        return self._chunker.split_text(text)
 
 
 class LangChainRecursiveCharacterTextSplitter(BaseModel, Chunker):
@@ -126,4 +127,5 @@ class LangChainRecursiveCharacterTextSplitter(BaseModel, Chunker):
         Returns:
             list[str]: A list of chunked strings.
         """
-        return self._chunker.split_text(item[self.chunk_column])
+        text = item[self.chunk_column] or ""
+        return self._chunker.split_text(text)


### PR DESCRIPTION
The chunking configuration takes a 'chunk_column' parameter, which determines which column of the source row is chunked.

This commit treats a null entry as being equivalent to the empty string, and no embeddings are generated.

Fixes #334 