### PR TITLE
chore: re-enable pgspot linting now that pgspot bug is fixed

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -652,7 +652,7 @@ def lint_py() -> None:
 
 def lint() -> None:
     lint_py()
-    # lint_sql()  # TODO: enable this when pgspot is fixed
+    lint_sql()
 
 
 def format_py() -> None:


### PR DESCRIPTION
pgspot had a [bug](https://github.com/timescale/pgspot/pull/213) that caused our lint step to fail on valid plpgsql code. That bug has been [fixed](https://github.com/timescale/pgspot/pull/213), so this PR re-enables the linting.