### PR TITLE
chore: fix uv caching

### DIFF
--- a/projects/extension/pyproject.toml
+++ b/projects/extension/pyproject.toml
@@ -76,3 +76,6 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.uv]
+reinstall-package = ["pgai"]


### PR DESCRIPTION
uv caches info about local packages you are installing unless some special files are touched. This prevents changes to local files being installed and thus makes the development workflow broken.

Turn off caching on the local package