### PR TITLE
Upgrade Ollama client version to support custom URL path in client URL

### DIFF
--- a/projects/extension/old_requirements.txt
+++ b/projects/extension/old_requirements.txt
@@ -1,5 +1,5 @@
 openai==1.30.2
 tiktoken==0.7.0
-ollama==0.2.1
+ollama==0.4.5
 anthropic==0.29.0
 cohere==5.5.8

--- a/projects/extension/requirements.txt
+++ b/projects/extension/requirements.txt
@@ -1,6 +1,6 @@
 openai==1.44.0
 tiktoken==0.7.0
-ollama==0.2.1
+ollama==0.4.5
 anthropic==0.29.0
 cohere==5.5.8
 backoff==2.2.1

--- a/projects/extension/setup.cfg
+++ b/projects/extension/setup.cfg
@@ -9,7 +9,7 @@ packages = ai
 install_requires =
     openai==1.44.0
     tiktoken==0.7.0
-    ollama==0.2.1
+    ollama==0.4.5
     anthropic==0.29.0
     cohere==5.5.8
     backoff==2.2.1


### PR DESCRIPTION
1. Ollama Client add this custom URL path support in [v0.3.2](https://github.com/ollama/ollama-python/releases/tag/v0.3.2)
2. pgai extension is still using v0.2.1 ollama client