### PR TITLE
docs: add vectorizer-quick-start-ollama.md file with link

### DIFF
--- a/docs/vectorizer-quick-start-ollama.md
+++ b/docs/vectorizer-quick-start-ollama.md
@@ -1,0 +1,1 @@
+## Go to our vectorizer-quickstart [here](/docs/vectorizer-quick-start.md) to start with pgai and ollama.


### PR DESCRIPTION
I thought maybe we can symlink this, but github doesn't seem to resolve those. E.g. when you click on the file you don't end up on the linked md file.

Alternatively leave this as an accepted drawback of using github for docs. If we ever host the pgai docs on a real docs website (or merge them into timescales docs) we can revisit this.

I don't feel strongly either way.