### PR TITLE
chore: restrict concurrency of ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on: [pull_request, workflow_dispatch]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test-extension:
     services:


### PR DESCRIPTION
Restricts the concurrency of the ci workflow - aborting existing jobs on the same pull request.