### PR TITLE
fix: ai._table_def returning null if no indexes

### DIFF
--- a/projects/extension/sql/idempotent/905-text-to-sql.sql
+++ b/projects/extension/sql/idempotent/905-text-to-sql.sql
@@ -64,7 +64,7 @@ begin
     ;
 
     -- indexes
-    select pg_catalog.string_agg(pg_catalog.pg_get_indexdef(i.indexrelid, 0, true), E';\n')
+    select coalesce(pg_catalog.string_agg(pg_catalog.pg_get_indexdef(i.indexrelid, 0, true), E';\n'), '')
     into strict _indexes
     from pg_catalog.pg_index i
     where i.indrelid operator(pg_catalog.=) objid


### PR DESCRIPTION
Fixes a bug where doing `ai._table_def` will return `null` if the referenced oid does not have any indexes. To reproduce, do:

```sql
CREATE TABLE public.city (
    city_name text,
    population bigint,
    country_name text DEFAULT ''::text NOT NULL,
    state_name text
);

SELECT ai._table_def('public.city'::regclass::oid) IS NULL
```

where the second query will return `true`.