### PR TITLE
docs: fix quickstart, retrieve ollama model

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,6 +1,10 @@
 name: Lint Commit Messages
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -43,6 +43,13 @@ On your local machine:
     docker compose up -d
     ```
 
+1. **Download the Ollama models.** We'll use the `nomic-embed-text` model to generate embeddings.
+
+    ```
+    docker compose exec ollama ollama pull nomic-embed-text
+    ```
+
+
 ## Create and run a vectorizer
 
 Now we can create and run a vectorizer. A vectorizer is a pgai concept, it processes data in a table and automatically creates embeddings for it.
@@ -114,7 +121,8 @@ Now we can create and run a vectorizer. A vectorizer is a pgai concept, it proce
         chunk,
         embedding <=>  ai.ollama_embed('nomic-embed-text', 'good food', host => 'http://ollama:11434') as distance
     FROM blog_contents_embeddings
-    ORDER BY distance;
+    ORDER BY distance
+    LIMIT;
     ```
 
 The results look like:


### PR DESCRIPTION
We were not retrieving the model on this example, fix the vectorizer-quick-start.
Also limit results to have better accuracy on results.

Finally add concurrency to prevent several subsequent commits
to run CI multiple times.