### PR TITLE
docs: switch to 'latest' tag for vectorizer worker docker image

### DIFF
--- a/docs/vectorizer-quick-start-openai.md
+++ b/docs/vectorizer-quick-start-openai.md
@@ -29,7 +29,7 @@ On your local machine:
         volumes:
           - data:/home/postgres/pgdata/data
       vectorizer-worker:
-        image: timescale/pgai-vectorizer-worker:v0.2.1
+        image: timescale/pgai-vectorizer-worker:latest
         environment:
           PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
           OPENAI_API_KEY: <your-api-key>

--- a/docs/vectorizer-quick-start-voyage.md
+++ b/docs/vectorizer-quick-start-voyage.md
@@ -27,7 +27,7 @@ On your local machine:
        volumes:
          - data:/home/postgres/pgdata/data
      vectorizer-worker:
-       image: timescale/pgai-vectorizer-worker:v0.3.0
+       image: timescale/pgai-vectorizer-worker:latest
        environment:
          PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
          VOYAGE_API_KEY: your-api-key

--- a/docs/vectorizer-quick-start.md
+++ b/docs/vectorizer-quick-start.md
@@ -27,7 +27,7 @@ On your local machine:
        volumes:
          - data:/home/postgres/pgdata/data
      vectorizer-worker:
-       image: timescale/pgai-vectorizer-worker:v0.2.1
+       image: timescale/pgai-vectorizer-worker:latest
        environment:
          PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
          OLLAMA_HOST: http://ollama:11434
@@ -42,13 +42,6 @@ On your local machine:
    ```shell
     docker compose up -d
     ```
-
-1. **Download the Ollama models.** We'll use the `nomic-embed-text` model to generate embeddings.
-
-    ```
-    docker compose exec ollama ollama pull nomic-embed-text
-    ```
-
 
 ## Create and run a vectorizer
 

--- a/docs/vectorizer-worker.md
+++ b/docs/vectorizer-worker.md
@@ -65,7 +65,7 @@ On your local machine:
         volumes:
           - data:/var/lib/postgresql/data
       vectorizer-worker:
-        image: timescale/pgai-vectorizer-worker:v0.2.1
+        image: timescale/pgai-vectorizer-worker:latest
         environment:
           PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
           OLLAMA_HOST: http://ollama:11434

--- a/examples/evaluations/ollama_vectorizer/compose.yaml
+++ b/examples/evaluations/ollama_vectorizer/compose.yaml
@@ -10,7 +10,7 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
   vectorizer-worker:
-    image: timescale/pgai-vectorizer-worker:v0.2.1
+    image: timescale/pgai-vectorizer-worker:latest
     environment:
       PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
       OPENAI_API_KEY: "sk-proj-"

--- a/examples/evaluations/voyage_vectorizer/compose.yaml
+++ b/examples/evaluations/voyage_vectorizer/compose.yaml
@@ -11,7 +11,7 @@ services:
    volumes:
      - data:/home/postgres/pgdata/data
  vectorizer-worker:
-   image: timescale/pgai-vectorizer-worker:v0.3.0
+   image: timescale/pgai-vectorizer-worker:latest
    environment:
      PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
      VOYAGE_API_KEY: your-key-here

--- a/examples/finding_best_open_source_embedding_model/compose.yaml
+++ b/examples/finding_best_open_source_embedding_model/compose.yaml
@@ -9,7 +9,7 @@ services:
    volumes:
      - data:/home/postgres/pgdata/data
  vectorizer-worker:
-   image: timescale/pgai-vectorizer-worker:v0.2.1
+   image: timescale/pgai-vectorizer-worker:latest
    environment:
      PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
      OLLAMA_HOST: http://ollama:11434


### PR DESCRIPTION
We were using a pinned version for the vectorizer worker docker image in our docker compose examples. As a result, the behaviour of the docker compose examples didn't reflect our documentations.

This commit switches all usages of `timescale/pgai-vectorizer-worker` to use the `latest` tag.