### PR TITLE
feat: add warning when trying to install pre-release version

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+export ROOT_JUSTFILE := "1" # Note: used in extension build.py
+
 # pgai python library. List recipes with `just -l pgai`
 mod pgai 'projects/pgai/justfile'
 # pgai postgres extension. List recipes with `just -l ext`

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 from pathlib import Path
 
 
@@ -583,7 +584,33 @@ def build() -> None:
     build_sql()
 
 
+def error_if_pre_release() -> None:
+    # Note: released versions always have the output sql file commited into the repository.
+    output_file = output_sql_file()
+    command = (
+        "just ext build-install"
+        if "ROOT_JUSTFILE" in os.environ
+        else "just build-install"
+        if "PROJECT_JUSTFILE" in os.environ
+        else "python3 build.py build-install"
+    )
+    if not Path(output_file).exists():
+        print(
+            textwrap.dedent(f"""
+                WARNING: You're trying to install a pre-release version of pgai.
+                This is not supported, and there is no upgrade path.
+
+                Instead, install an official release from https://github.com/timescale/pgai/releases.
+
+                If you are certain that you want to install a pre-release version, run:
+                    `{command}`
+            """)
+        )
+        exit(1)
+
+
 def install() -> None:
+    error_if_pre_release()
     install_prior_py()
     install_py()
     install_sql()

--- a/projects/extension/justfile
+++ b/projects/extension/justfile
@@ -1,3 +1,4 @@
+export PROJECT_JUSTFILE := "1" # Note: used in build.py
 PG_MAJOR := env("PG_MAJOR", "17")
 PG_BIN := env("PG_BIN", "/usr/lib/postgresql/" + PG_MAJOR + "/bin")
 


### PR DESCRIPTION
Pre-release versions of the pgai extension do not have a defined upgrade
path to released versions. Installing these versions could leave
databases in a problematic state that cannot be cleanly upgraded.

This change prevents accidental installation of development builds by
directing users to official releases, while still allowing intentional
installation of pre-release versions via the explicit build-install
command.
