### PR TITLE
chore: allow the creation of blank issues in this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: pgai discord
     url: https://discord.gg/KRdHVXAmkp


### PR DESCRIPTION
I believe we should not be that restrictive with users that want to create an issue and allow them to create blank issues if they don't find a template that fits with their needs.