### PR TITLE
test: do not run pre-release tests on a release build

### DIFF
--- a/projects/extension/tests/text_to_sql/test_dump_restore.py
+++ b/projects/extension/tests/text_to_sql/test_dump_restore.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+import re
 
 import psycopg
 import pytest
@@ -18,6 +19,21 @@ DST_DB = "text_to_sql_dst"
 
 def db_url(user: str, dbname: str) -> str:
     return f"postgres://{user}@127.0.0.1:5432/{dbname}"
+
+
+# skip tests in this module if this is NOT a pre-release build
+with psycopg.connect(
+    db_url(user="postgres", dbname="postgres"), autocommit=True
+) as con:
+    with con.cursor() as cur:
+        cur.execute(
+            """select default_version from pg_available_extensions where name = 'ai'"""
+        )
+        version = cur.fetchone()[0]
+        parts = re.split(r"[.-]", version, maxsplit=4)
+        if len(parts) == 3:  # if this is a release version
+            # skip these tests
+            pytest.skip(allow_module_level=True)
 
 
 def where_am_i() -> str:


### PR DESCRIPTION
- When prepping for a release, we change [the current version](https://github.com/timescale/pgai/blob/main/projects/extension/build.py#L43) to a release version (e.g. `0.7.0`) and remove any pre-release tag (e.g. `0.7.0-dev`). 
- Then, we build the output SQL and check it in.
- When we build output SQL, if we are building a release version, we omit any code that is behind a feature flag
- If feature flagged code has tests, then those tests need to detect that this is a release build and be skipped. If they attempt to run, the code they are testing will not exist in the database.

This PR modifies the text-to-sql tests to detect whether or not the current version is a release build. If it is a release build, the tests are skipped.