### PR TITLE
Add `build-release` and `reformat-py` just commands

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -33,6 +33,7 @@ HELP = """Available targets:
 - lint-py          runs ruff linter against the python source files
 - lint             runs both sql and python linters
 - format-py        runs ruff to check formatting of the python source files
+- reformat-py      runs ruff to update the formatting of the python source files
 - docker-build     builds the dev docker image
 - docker-run       launches a container in docker using the docker image
 - docker-stop      stops the container
@@ -669,6 +670,10 @@ def format_py() -> None:
     )
 
 
+def reformat_py() -> None:
+    subprocess.run(f"ruff format {ext_dir()}", shell=True, check=True, env=os.environ)
+
+
 def docker_build() -> None:
     subprocess.run(
         f"""docker build --build-arg PG_MAJOR={pg_major()} -t pgai-ext .""",
@@ -778,6 +783,8 @@ if __name__ == "__main__":
             lint()
         elif action == "format-py":
             format_py()
+        elif action == "reformat-py":
+            reformat_py()
         elif action == "docker-build":
             docker_build()
         elif action == "docker-run":

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -26,6 +26,7 @@ HELP = """Available targets:
 - clean            removes python build artifacts from the src dir
 - clean-sql        removes sql file artifacts from the sql dir
 - clean-py         removes python build artifacts from the extension src dir
+- build-release    runs build-sql and updates the version in __init__.py
 - test             runs the tests in the docker container
 - test-server      runs the test http server in the docker container
 - lint-sql         runs pgspot against the `ai--<this_version>.sql` file
@@ -599,6 +600,13 @@ def clean() -> None:
     clean_py()
 
 
+def build_release() -> None:
+    clean_sql()
+    clean_py()
+    build()
+    build_init_py()
+
+
 def tests_dir() -> Path:
     return ext_dir().joinpath("tests").absolute()
 
@@ -750,6 +758,8 @@ if __name__ == "__main__":
             clean_py()
         elif action == "clean":
             clean()
+        elif action == "build-release":
+            build_release()
         elif action == "uninstall-py":
             uninstall_py()
         elif action == "uninstall-sql":

--- a/projects/extension/justfile
+++ b/projects/extension/justfile
@@ -82,6 +82,9 @@ lint:
 format-py:
 	@./build.py format-py
 
+reformat-py:
+	@./build.py reformat-py
+
 docker-build:
 	@PG_MAJOR={{PG_MAJOR}} ./build.py docker-build
 

--- a/projects/extension/justfile
+++ b/projects/extension/justfile
@@ -61,6 +61,9 @@ freeze:
 build-sql:
 	@./build.py build-sql
 
+build-release:
+    @./build.py build-release
+
 test-server:
 	@./build.py test-server
 


### PR DESCRIPTION
When prepping for a release, we need to 

1. build and commit the output sql
2. update the __version__ in __init__.py

This new `just build-release` command will do those steps without installing anything into the system.

We have a `just format-py` to check the python formatting using ruff. This adds a `just reformat-py` which will run ruff to correct the formatting automatically.