### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
+* @timescale/ts-vector


### PR DESCRIPTION
Adding a `CODEOWNERS` file gives transparency to all users about who are the owners of this project. This also allows, among other stuff, to automatically assign the `ts-vector` team as reviewer for new PR's.