### PR TITLE
feat: add ai.anthropic_list_models

### DIFF
--- a/projects/extension/ai/anthropic.py
+++ b/projects/extension/ai/anthropic.py
@@ -1,5 +1,6 @@
-from typing import Optional
 from anthropic import Anthropic
+from datetime import datetime
+from typing import Optional, Generator
 
 DEFAULT_KEY_NAME = "ANTHROPIC_API_KEY"
 
@@ -16,3 +17,13 @@ def make_client(
     if max_retries is not None:
         args["max_retries"] = max_retries
     return Anthropic(api_key=api_key, base_url=base_url, **args)
+
+
+def list_models(
+    api_key: str,
+    base_url: Optional[str] = None,
+) -> Generator[tuple[str, datetime], None, None]:
+    client = make_client(api_key, base_url)
+
+    for model in client.models.list():
+        yield model.id, model.display_name, model.created_at

--- a/projects/extension/ai/anthropic.py
+++ b/projects/extension/ai/anthropic.py
@@ -22,7 +22,7 @@ def make_client(
 def list_models(
     api_key: str,
     base_url: Optional[str] = None,
-) -> Generator[tuple[str, datetime], None, None]:
+) -> Generator[tuple[str, str, datetime], None, None]:
     client = make_client(api_key, base_url)
 
     for model in client.models.list():

--- a/projects/extension/sql/idempotent/003-anthropic.sql
+++ b/projects/extension/sql/idempotent/003-anthropic.sql
@@ -1,4 +1,24 @@
 -------------------------------------------------------------------------------
+-- anthropic_list_models
+-- https://docs.anthropic.com/en/api/models-list
+create or replace function ai.anthropic_list_models(api_key text default null, api_key_name text default null, base_url text default null)
+returns table
+( id text
+, name text
+, created timestamptz
+)
+as $python$
+    #ADD-PYTHON-LIB-DIR
+    import ai.anthropic
+    import ai.secrets
+    api_key_resolved = ai.secrets.get_secret(plpy, api_key, api_key_name, ai.anthropic.DEFAULT_KEY_NAME, SD)
+    yield from ai.anthropic.list_models(api_key_resolved, base_url)
+$python$
+language plpython3u volatile parallel safe security invoker
+set search_path to pg_catalog, pg_temp
+;
+
+-------------------------------------------------------------------------------
 -- anthropic_generate
 -- https://docs.anthropic.com/en/api/messages
 create or replace function ai.anthropic_generate

--- a/projects/extension/tests/contents/output16.expected
+++ b/projects/extension/tests/contents/output16.expected
@@ -6,6 +6,7 @@ CREATE EXTENSION
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  event trigger _vectorizer_handle_drops
  function ai.anthropic_generate(text,jsonb,integer,text,text,text,double precision,integer,text,text,text[],double precision,jsonb,jsonb,integer,double precision)
+ function ai.anthropic_list_models(text,text,text)
  function ai.chunking_character_text_splitter(name,integer,integer,text,boolean)
  function ai.chunking_recursive_character_text_splitter(name,integer,integer,text[],boolean)
  function ai.cohere_chat_complete(text,text,text,text,text,jsonb,text,text,jsonb,boolean,jsonb,text,double precision,integer,integer,integer,double precision,integer,text[],double precision,double precision,jsonb,jsonb,boolean)
@@ -94,7 +95,7 @@ CREATE EXTENSION
  table ai.vectorizer_errors
  view ai.secret_permissions
  view ai.vectorizer_status
-(90 rows)
+(91 rows)
 
                                     Table "ai._secret_permissions"
  Column | Type | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 

--- a/projects/extension/tests/contents/output17.expected
+++ b/projects/extension/tests/contents/output17.expected
@@ -6,6 +6,7 @@ CREATE EXTENSION
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  event trigger _vectorizer_handle_drops
  function ai.anthropic_generate(text,jsonb,integer,text,text,text,double precision,integer,text,text,text[],double precision,jsonb,jsonb,integer,double precision)
+ function ai.anthropic_list_models(text,text,text)
  function ai.chunking_character_text_splitter(name,integer,integer,text,boolean)
  function ai.chunking_recursive_character_text_splitter(name,integer,integer,text[],boolean)
  function ai.cohere_chat_complete(text,text,text,text,text,jsonb,text,text,jsonb,boolean,jsonb,text,double precision,integer,integer,integer,double precision,integer,text[],double precision,double precision,jsonb,jsonb,boolean)
@@ -108,7 +109,7 @@ CREATE EXTENSION
  type ai.vectorizer_status[]
  view ai.secret_permissions
  view ai.vectorizer_status
-(104 rows)
+(105 rows)
 
                                     Table "ai._secret_permissions"
  Column | Type | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 

--- a/projects/extension/tests/privileges/function.expected
+++ b/projects/extension/tests/privileges/function.expected
@@ -108,6 +108,10 @@
  f       | bob   | execute   | no      | ai     | anthropic_generate(model text, messages jsonb, max_tokens integer, api_key text, api_key_name text, base_url text, timeout double precision, max_retries integer, system_prompt text, user_id text, stop_sequences text[], temperature double precision, tool_choice jsonb, tools jsonb, top_k integer, top_p double precision)
  f       | fred  | execute   | no      | ai     | anthropic_generate(model text, messages jsonb, max_tokens integer, api_key text, api_key_name text, base_url text, timeout double precision, max_retries integer, system_prompt text, user_id text, stop_sequences text[], temperature double precision, tool_choice jsonb, tools jsonb, top_k integer, top_p double precision)
  f       | jill  | execute   | YES     | ai     | anthropic_generate(model text, messages jsonb, max_tokens integer, api_key text, api_key_name text, base_url text, timeout double precision, max_retries integer, system_prompt text, user_id text, stop_sequences text[], temperature double precision, tool_choice jsonb, tools jsonb, top_k integer, top_p double precision)
+ f       | alice | execute   | YES     | ai     | anthropic_list_models(api_key text, api_key_name text, base_url text)
+ f       | bob   | execute   | no      | ai     | anthropic_list_models(api_key text, api_key_name text, base_url text)
+ f       | fred  | execute   | no      | ai     | anthropic_list_models(api_key text, api_key_name text, base_url text)
+ f       | jill  | execute   | YES     | ai     | anthropic_list_models(api_key text, api_key_name text, base_url text)
  f       | alice | execute   | YES     | ai     | chunking_character_text_splitter(chunk_column name, chunk_size integer, chunk_overlap integer, separator text, is_separator_regex boolean)
  f       | bob   | execute   | no      | ai     | chunking_character_text_splitter(chunk_column name, chunk_size integer, chunk_overlap integer, separator text, is_separator_regex boolean)
  f       | fred  | execute   | no      | ai     | chunking_character_text_splitter(chunk_column name, chunk_size integer, chunk_overlap integer, separator text, is_separator_regex boolean)
@@ -328,5 +332,5 @@
  f       | bob   | execute   | no      | ai     | voyageai_embed(model text, input_texts text[], input_type text, api_key text, api_key_name text)
  f       | fred  | execute   | no      | ai     | voyageai_embed(model text, input_texts text[], input_type text, api_key text, api_key_name text)
  f       | jill  | execute   | YES     | ai     | voyageai_embed(model text, input_texts text[], input_type text, api_key text, api_key_name text)
-(328 rows)
+(332 rows)
 

--- a/projects/extension/tests/test_anthropic.py
+++ b/projects/extension/tests/test_anthropic.py
@@ -42,6 +42,38 @@ def cur_with_external_functions_executor_url(cur) -> psycopg.Cursor:
         yield cur
 
 
+def test_anthropic_list_models(cur, anthropic_api_key):
+    cur.execute(
+        """
+        select count(*) > 0 as actual
+        from ai.anthropic_list_models(api_key=>%s)
+    """,
+        (anthropic_api_key,),
+    )
+    actual = cur.fetchone()[0]
+    assert actual > 0
+
+
+def test_anthropic_list_models_api_key_name(cur_with_external_functions_executor_url):
+    cur_with_external_functions_executor_url.execute(
+        """
+        select count(*) > 0 as actual
+        from ai.anthropic_list_models(api_key_name=> 'ANTHROPIC_API_KEY_REAL')
+    """
+    )
+    actual = cur_with_external_functions_executor_url.fetchone()[0]
+    assert actual > 0
+
+
+def test_anthropic_list_models_no_key(cur_with_api_key):
+    cur_with_api_key.execute("""
+        select count(*) > 0 as actual
+        from ai.anthropic_list_models()
+    """)
+    actual = cur_with_api_key.fetchone()[0]
+    assert actual > 0
+
+
 def test_anthropic_generate(cur, anthropic_api_key):
     cur.execute(
         """


### PR DESCRIPTION
PR implements the `ai.anthropic_list_models` function, which currently returns columns `(id, name, created)` which gives:

```
test=# SELECT ai.anthropic_list_models();
                              anthropic_list_models
---------------------------------------------------------------------------------
 (claude-3-5-sonnet-20241022,"Claude 3.5 Sonnet (New)","2024-10-22 00:00:00+00")
 (claude-3-5-haiku-20241022,"Claude 3.5 Haiku","2024-10-22 00:00:00+00")
 (claude-3-5-sonnet-20240620,"Claude 3.5 Sonnet (Old)","2024-06-20 00:00:00+00")
 (claude-3-haiku-20240307,"Claude 3 Haiku","2024-03-07 00:00:00+00")
 (claude-3-opus-20240229,"Claude 3 Opus","2024-02-29 00:00:00+00")
 (claude-3-sonnet-20240229,"Claude 3 Sonnet","2024-02-29 00:00:00+00")
 (claude-2.1,"Claude 2.1","2023-11-21 00:00:00+00")
 (claude-2.0,"Claude 2.0","2023-07-11 00:00:00+00")
(8 rows)
```