### PR TITLE
feat(vectorizer): disable OpenAI tokenization when a model does not have a tokenizer match

### DIFF
--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -48,7 +48,7 @@ class EmbeddingResponse:
     usage: Usage
 
 
-T = TypeVar("T", StringDocument, TokenDocument)
+T = TypeVar("T", StringDocument, TokenDocument, Document)
 
 
 @dataclass


### PR DESCRIPTION
## Context

At this moment, we are tokenizing the chunks before being sent to OpenAI embedding API. The way that's done is through matching a tokenizer with the given OpenAI model thanks to tiktoken. See [here](https://github.com/timescale/pgai/blob/main/projects/pgai/pgai/vectorizer/embedders/openai.py#L203-L205).

That works because tiktoken has a map of `openai_model => tokenizer`.  
Notice that **is only compatible with OpenAI models**.

## Description
This PR allows to skip tokenization whenever we are not able to find a tokenizer for a given model. 

Why this is needed? Because two reasons:

1. Since tiktoken is only compatible with OpenAI models, the call made to match a non-openai model with a tokenizer will always fail.
2. Not all LLM providers accept tokenized input but rather just plain text.

That, among the recently `base_url` param we added in our latest release, this will allow to call any other LLM with an API compatible with OpenAI. 


Relates to https://github.com/timescale/pgai/issues/352