### PR TITLE
build: ignore sql files with 'x' prefix

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -121,7 +121,9 @@ def idempotent_sql_dir() -> Path:
 
 
 def idempotent_sql_files() -> list[Path]:
-    paths = [x for x in idempotent_sql_dir().glob("*.sql") if not x.name.startswith("x")]
+    paths = [
+        x for x in idempotent_sql_dir().glob("*.sql") if not x.name.startswith("x")
+    ]
     paths.sort()
     return paths
 
@@ -131,7 +133,9 @@ def incremental_sql_dir() -> Path:
 
 
 def incremental_sql_files() -> list[Path]:
-    paths = [x for x in incremental_sql_dir().glob("*.sql") if not x.name.startswith("x")]
+    paths = [
+        x for x in incremental_sql_dir().glob("*.sql") if not x.name.startswith("x")
+    ]
     paths.sort()
     return paths
 


### PR DESCRIPTION
While developing, sometimes I want to implement something a few different ways and compare. The easiest thing to do is to keep each version in a separate SQL file. But I can only have one at a time built and tested.

I don't want to

1. move the SQL file to another directory - this is a pain and I still want to be able to look at the file in my editor in the context of the project
2. comment out the entire body of the SQL - also a pain and destroys and IDE niceties
3. delete the file - I haven't decided to discard the work

What I want is an easy way to temporarily ignore a SQL file while I'm developing.

This PR allows you to rename a SQL file to add an 'x' prefix to tell the build to ignore the file.