### PR TITLE
chore: get rid of nested parametrization in vectorizer tests

### DIFF
--- a/projects/pgai/tests/vectorizer/extensions/test_inheritance.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_inheritance.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import run_vectorizer_worker
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 class BaseModel(DeclarativeBase):

--- a/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy.py
@@ -6,7 +6,7 @@ from sqlalchemy.sql import text
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import run_vectorizer_worker
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 def test_sqlalchemy(

--- a/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_composite_primary.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_composite_primary.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql import text
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import run_vectorizer_worker
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 class Base(DeclarativeBase):

--- a/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_large_embeddings.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_large_embeddings.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql import text
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import run_vectorizer_worker
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 class Base(DeclarativeBase):

--- a/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_lazy_strategies.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_lazy_strategies.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql import text
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import run_vectorizer_worker
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 class Base(DeclarativeBase):

--- a/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_relationship.py
+++ b/projects/pgai/tests/vectorizer/extensions/test_sqlalchemy_relationship.py
@@ -7,9 +7,7 @@ from sqlalchemy.sql import text
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai.sqlalchemy import vectorizer_relationship
-from tests.vectorizer.extensions.utils import (
-    run_vectorizer_worker,
-)
+from tests.vectorizer.utils import run_vectorizer_worker
 
 
 class Base(DeclarativeBase):

--- a/projects/pgai/tests/vectorizer/extensions/utils.py
+++ b/projects/pgai/tests/vectorizer/extensions/utils.py
@@ -1,27 +1,9 @@
 from pathlib import Path
 from typing import Any
 
-from click.testing import CliRunner
 from sqlalchemy import Column
 
-from pgai.cli import vectorizer_worker
 from tests.vectorizer.extensions.conftest import load_template
-
-
-def run_vectorizer_worker(db_url: str, vectorizer_id: int) -> None:
-    CliRunner().invoke(
-        vectorizer_worker,
-        [
-            "--db-url",
-            db_url,
-            "--once",
-            "--vectorizer-id",
-            str(vectorizer_id),
-            "--concurrency",
-            "1",
-        ],
-        catch_exceptions=False,
-    )
 
 
 def create_vectorizer_migration(

--- a/projects/pgai/tests/vectorizer/utils.py
+++ b/projects/pgai/tests/vectorizer/utils.py
@@ -1,0 +1,28 @@
+from click.testing import CliRunner, Result
+
+from pgai.cli import vectorizer_worker
+
+
+def run_vectorizer_worker(
+    db_url: str,
+    vectorizer_id: int | None = None,
+    concurrency: int = 1,
+    extra_params: list[str] | None = None,
+) -> Result:
+    args = [
+        "--db-url",
+        db_url,
+        "--once",
+        "--concurrency",
+        str(concurrency),
+    ]
+    if vectorizer_id is not None:
+        args.extend(["--vectorizer-id", str(vectorizer_id)])
+    if extra_params:
+        args.extend(extra_params)
+
+    return CliRunner().invoke(
+        vectorizer_worker,
+        args,
+        catch_exceptions=False,
+    )

--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -2053,7 +2053,6 @@ wheels = [
 
 [[package]]
 name = "pgai"
-version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Refactors the vectorizer test suite to be more easily readable by:
- Removing nested test_params fixture (num_items, concurrency, batch_size, chunking, formatting) in favor of direct parameters that are then passed to setup functions
- Creating dedicated configuration functions (configure_openai_vectorizer, configure_ollama_vectorizer, etc.) to replace the fixtures
- Using a common `run_vectorizer_worker` helper function standardizing CLI invocation

I also want to split the file up, but wondering how and if I should do that separately.