### PR TITLE
fix: remove sqlalchemy warning about conflicts

### DIFF
--- a/projects/pgai/pgai/sqlalchemy/__init__.py
+++ b/projects/pgai/pgai/sqlalchemy/__init__.py
@@ -180,6 +180,7 @@ class _Vectorizer:
                     foreign_keys=[
                         getattr(self._embedding_class, col.name) for col in pk_cols
                     ],
+                    back_populates="parent",
                     **self.relationship_args,
                 )
                 setattr(owner, f"{self.name}_model", self._embedding_class)


### PR DESCRIPTION
Fixes #406 
Functionally this doesn't change anything. It just makes it so that if you would somehow attach an embedding to a different parent entity the `.parent` is correctly changed as well. However I don't see this as a valid use-case since the vectorizer is in charge of keeping the embeddings in sync. Therefore I didn't write a test for this, and just added the line to remove the warning by sqlalchemy in the log.