### PR TITLE
feat: add table sample tool to text-to-sql

### DIFF
--- a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
+++ b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
@@ -6,6 +6,7 @@
 create function ai.text_to_sql_render_prompt
 ( question text
 , obj_prompt text
+, samples_sql text
 , sql_prompt text
 ) returns text
 as $func$
@@ -16,6 +17,8 @@ as $func$
     , $$If enough context has been provided to confidently address the question, use the "answer_user_question_with_sql_statement" tool to record your final answer in the form of a valid SQL statement.$$
     , E'\n'
     , coalesce(obj_prompt, '')
+    , E'\n'
+    , coalesce(samples_sql, '')
     , E'\n'
     , coalesce(sql_prompt, '')
     , E'\n'
@@ -115,6 +118,8 @@ declare
     _sql text;
     _prompt_obj text;
     _prompt_sql text;
+    _samples jsonb = '{}';
+    _samples_sql text;
     _prompt text;
     _system_prompt text;
     _tools jsonb;
@@ -130,7 +135,7 @@ begin
     _max_vector_dist = (_config->>'max_vector_dist')::float8;
     _obj_renderer = coalesce((_config->>'obj_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_obj(bigint, oid, oid)'::pg_catalog.regprocedure);
     _sql_renderer = coalesce((_config->>'sql_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_sql(bigint, text, text)'::pg_catalog.regprocedure);
-    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text)'::pg_catalog.regprocedure);
+    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text, text)'::pg_catalog.regprocedure);
     _model = coalesce(_config->>'model', 'claude-3-5-sonnet-latest');
     _max_tokens = coalesce(_config operator(pg_catalog.->>) 'max_tokens', '1024')::int4;
     _api_key = _config operator(pg_catalog.->>) 'api_key';
@@ -252,6 +257,13 @@ begin
         ;
         execute _sql using _ctx_obj into _prompt_obj;
 
+        -- render samples
+        raise debug 'rendering table samples';
+        select string_agg(value, E'\n\n')
+        into strict _samples_sql
+        from jsonb_each_text(_samples)
+        ;
+
         -- render sql
         raise debug 'rendering sql examples';
         select format
@@ -272,7 +284,7 @@ begin
         -- render the user prompt
         raise debug 'rendering user prompt';
         select format
-        ( $sql$select %I.%I($1, $2, $3)$sql$
+        ( $sql$select %I.%I($1, $2, $3, $4)$sql$
         , n.nspname
         , f.proname
         )
@@ -281,7 +293,7 @@ begin
         inner join pg_namespace n on (f.pronamespace = n.oid)
         where f.oid = _prompt_renderer::oid
         ;
-        execute _sql using question, _prompt_obj, _prompt_sql into _prompt;
+        execute _sql using question, _prompt_obj, _samples_sql, _prompt_sql into _prompt;
         raise debug '%', _prompt;
 
         -- call llm -----------------------------------------------------------
@@ -299,6 +311,24 @@ begin
                         }
                     },
                     "required": ["question"]
+                }
+            },
+            {
+                "name": "request_table_sample",
+                "description": "If you do not have enough context about a table to confidently answer the user's question, use this tool to ask for a sample of the table's data.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the table or view to sample."
+                        },
+                        "total": {
+                            "type": "integer",
+                            "description": "The total number of rows to return in the sample."
+                        }
+                    },
+                    "required": ["name", "total"]
                 }
             },
             {
@@ -328,7 +358,7 @@ begin
         ]
         $json$::jsonb
         ;
-    
+
         raise debug 'calling llm';
         select ai.anthropic_generate
         ( _model
@@ -375,6 +405,11 @@ begin
                             -- append the question to the list of questions to use on the next iteration
                             select _questions || jsonb_build_array(_message.input->'question')
                             into strict _questions
+                            ;
+                        when 'request_table_sample' then
+                            raise debug 'tool use: request_table_sample';
+                            select _samples || jsonb_build_object(_message.input->'name', ai.render_sample(_message.input->'name', _message.input->'total'))
+                            into strict _samples
                             ;
                         when 'answer_user_question_with_sql_statement' then
                             raise debug 'tool use: answer_user_question_with_sql_statement';

--- a/projects/extension/sql/idempotent/907-text-to-sql-ollama.sql
+++ b/projects/extension/sql/idempotent/907-text-to-sql-ollama.sql
@@ -80,7 +80,7 @@ begin
     _max_vector_dist = (_config->>'max_vector_dist')::float8;
     _obj_renderer = coalesce((_config->>'obj_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_obj(bigint, oid, oid)'::pg_catalog.regprocedure);
     _sql_renderer = coalesce((_config->>'sql_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_sql(bigint, text, text)'::pg_catalog.regprocedure);
-    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text)'::pg_catalog.regprocedure);
+    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text, text)'::pg_catalog.regprocedure);
     _model = coalesce(_config->>'model', 'claude-3-5-sonnet-latest');
     _host = config->>'host';
     _keep_alive = config->>'keep_alive';
@@ -214,7 +214,7 @@ begin
         -- render the user prompt
         raise debug 'rendering user prompt';
         select format
-        ( $sql$select %I.%I($1, $2, $3)$sql$
+        ( $sql$select %I.%I($1, $2, $3, $4)$sql$
         , n.nspname
         , f.proname
         )
@@ -223,7 +223,7 @@ begin
         inner join pg_namespace n on (f.pronamespace = n.oid)
         where f.oid = _prompt_renderer::oid
         ;
-        execute _sql using question, _prompt_obj, _prompt_sql into _prompt;
+        execute _sql using question, _prompt_obj, '', _prompt_sql into _prompt;
         raise debug '%', _prompt;
 
         -- call llm -----------------------------------------------------------

--- a/projects/extension/sql/idempotent/909-text-to-sql-cohere.sql
+++ b/projects/extension/sql/idempotent/909-text-to-sql-cohere.sql
@@ -103,7 +103,7 @@ begin
     _max_vector_dist = (_config->>'max_vector_dist')::float8;
     _obj_renderer = coalesce((_config->>'obj_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_obj(bigint, oid, oid)'::pg_catalog.regprocedure);
     _sql_renderer = coalesce((_config->>'sql_renderer')::pg_catalog.regprocedure, 'ai.render_semantic_catalog_sql(bigint, text, text)'::pg_catalog.regprocedure);
-    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text)'::pg_catalog.regprocedure);
+    _prompt_renderer = coalesce((_config->>'prompt_renderer')::pg_catalog.regprocedure, 'ai.text_to_sql_render_prompt(text, text, text, text)'::pg_catalog.regprocedure);
     _model = coalesce( _config->>'model', 'claude-3-5-sonnet-latest');
     _api_key = _config operator(pg_catalog.->>) 'api_key';
     _api_key_name = _config operator(pg_catalog.->>) 'api_key_name';
@@ -245,7 +245,7 @@ begin
         -- render the user prompt
         raise debug 'rendering user prompt';
         select format
-        ( $sql$select %I.%I($1, $2, $3)$sql$
+        ( $sql$select %I.%I($1, $2, $3, $4)$sql$
         , n.nspname
         , f.proname
         )
@@ -254,7 +254,7 @@ begin
         inner join pg_namespace n on (f.pronamespace = n.oid)
         where f.oid = _prompt_renderer::oid
         ;
-        execute _sql using question, _prompt_obj, _prompt_sql into _prompt;
+        execute _sql using question, _prompt_obj, '', _prompt_sql into _prompt;
         raise debug '%', _prompt;
 
         -- call llm -----------------------------------------------------------


### PR DESCRIPTION
PR adds a new tool to `ai.text_to_sql_openai` and `ai.text_to_sql_anthropic` to allow the LLM to fetch a sample of a table if it thinks it needs this context.

I've found that it doesn't seem to ever call this tool, but that can be improved/fixed in a follow-up PR.

This PR is built off #415, so will want to merge that one before merging this one.