### PR TITLE
chore: skip cohere classify tests

### DIFF
--- a/projects/extension/tests/test_cohere.py
+++ b/projects/extension/tests/test_cohere.py
@@ -233,6 +233,9 @@ def test_cohere_embed_no_key(cur_with_api_key):
     assert actual == 384
 
 
+@pytest.mark.skip(
+    reason="classification can only be performed on fine-tuned models, which we don't have"
+)
 def test_cohere_classify(cur_with_api_key):
     cur_with_api_key.execute("""
         with examples(example, label) as
@@ -259,6 +262,9 @@ def test_cohere_classify(cur_with_api_key):
     assert actual == """{"bird": "animal", "corn": "food", "airplane": "machine"}"""
 
 
+@pytest.mark.skip(
+    reason="classification can only be performed on fine-tuned models, which we don't have"
+)
 def test_cohere_classify_simple(cur_with_api_key):
     cur_with_api_key.execute("""
         with examples(example, label) as


### PR DESCRIPTION
Cohere recently changed their classify API to require using a pre-trained model [1]. We don't have a pretrained model, and until we decide to make one for these tests, we'll skip them.

[1]: https://docs.cohere.com/changelog/classify-default-model-deprecation