### PR TITLE
docs: change readme header to use links instead of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@
 
 <h3>Power your AI applications with PostgreSQL</h3>
 
-[![Discord](https://img.shields.io/badge/Join_us_on_Discord-black?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/KRdHVXAmkp)
-[![Try Timescale for free](https://img.shields.io/badge/Try_Timescale_for_free-black?style=for-the-badge&logo=timescale&logoColor=white)](https://tsdb.co/gh-pgai-signup)
+<div>
+  <a href="https://github.com/timescale/pgai/tree/main/docs"><strong>Docs</strong></a> ·
+  <a href="https://discord.gg/KRdHVXAmkp"><strong>Join the pgai Discord!</strong></a> ·
+  <a href="https://tsdb.co/gh-pgai-signup"><strong>Try timescale for free!</strong></a> ·
+  <a href="https://github.com/timescale/pgai/releases"><strong>Changelog</strong></a>
 </div>
-
+</div>
+<br/>
 Supercharge your PostgreSQL database with AI capabilities. Supports:  
 
 - Automatic creation and synchronization of vector embeddings for your data  


### PR DESCRIPTION
Looks like this:
<img width="848" alt="Screenshot 2025-02-06 at 09 32 57" src="https://github.com/user-attachments/assets/91b02a38-648e-42f6-b405-101eae0414c6" />
