### PR TITLE
fix: calling generate functions with openai

### DIFF
--- a/projects/extension/ai/semantic_catalog.py
+++ b/projects/extension/ai/semantic_catalog.py
@@ -161,7 +161,7 @@ def generate_description(
                     $1
                     , $2
                     , tools => $3
-                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'::jsonb
+                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'
                 )
             """,
             ["text", "jsonb", "jsonb"],
@@ -293,7 +293,7 @@ def generate_column_descriptions(
                     $1
                     , $2
                     , tools => $3
-                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'::jsonb
+                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'
                 )
             """,
             ["text", "jsonb", "jsonb"],
@@ -414,7 +414,7 @@ def generate_function_description(
                     $1
                     , $2
                     , tools => $3
-                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'::jsonb
+                    , tool_choice => '{"type": "function", "function": {"name": "generate_description"}}'
                 )
             """,
             ["text", "jsonb", "jsonb"],


### PR DESCRIPTION
PR fixes calling the `generate` functions with `openai` provider, where I was mistakenly passing `tool_choice` as a `jsonb` object, where it should have been a `text` value.