### PR TITLE
build(extension): add a 'just install-sql-all' command

### DIFF
--- a/projects/extension/DEVELOPMENT.md
+++ b/projects/extension/DEVELOPMENT.md
@@ -213,7 +213,7 @@ recipes in favor of the SQL-specific just recipes:
 
 1. **Build pgai**: run `just ext build` to compile idempotent and incremental scripts
    into `./projects/extension/sql/output/ai--*<current-version>.sql`.
-1. **Install pgai**: run `just ext install-sql` to install `./projects/extension/sql/output/ai--*.sql` and `./projects/extension/sql/output/ai*.control` into your local
+1. **Install pgai**: run `just ext install-sql-all` to install `./projects/extension/sql/output/ai--*.sql` and `./projects/extension/sql/output/ai*.control` into your local
    Postgres environment.
 
 ### Develop Python in the pgai extension

--- a/projects/extension/justfile
+++ b/projects/extension/justfile
@@ -44,6 +44,9 @@ build-install:
 install-sql:
 	@PG_BIN={{PG_BIN}} ./build.py install-sql
 
+install-sql-all:
+	@PG_BIN={{PG_BIN}} ./build.py install-sql all
+
 install-prior-py:
 	@./build.py install-prior-py
 


### PR DESCRIPTION
More often than not, when working on the extension, you are solely working on SQL and not modifying any Python. In this mode, you want to (re)install just the SQL files because it's practically instantaneous. You don't really want to bother reinstalling they Python bits, because 1. you didn't change it 2. it's substantially slower than installing the SQL.

`just install-sql` recently changed to only install the current version. This is fine, except that the upgrade tests will fail unless ALL the SQL versions are installed.

This PR adds `just install-sql-all` to give us the original behavior.