### PR TITLE
fix: readd version to uv lock

### DIFF
--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -2053,6 +2053,7 @@ wheels = [
 
 [[package]]
 name = "pgai"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
We recently [commited](https://github.com/timescale/pgai/pull/394#discussion_r1930412278) a uv.lock 
without pgai version specified, which broke uv proper functioning, possibly due to a discrepancy in the
uv version used.
