### PR TITLE
Revert pgai version inclusion in uv.lock

### DIFF
--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -2053,7 +2053,6 @@ wheels = [
 
 [[package]]
 name = "pgai"
-version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Reverts timescale/pgai#463

Not needed when using last versions of `uv`.