### PR TITLE
feat: support queue item retries 

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -405,7 +405,10 @@ declare
 begin
     -- create the table
     select pg_catalog.format
-    ( $sql$create table %I.%I(%s, queued_at timestamptz not null default now())$sql$
+    ( $sql$create table %I.%I(%s
+    , queued_at pg_catalog.timestamptz not null default now()
+    , retries pg_catalog.int4 default 0
+    , retry_after pg_catalog.timestamptz)$sql$
     , queue_schema, queue_table
     , (
         select pg_catalog.string_agg

--- a/projects/extension/sql/idempotent/013-loading.sql
+++ b/projects/extension/sql/idempotent/013-loading.sql
@@ -67,15 +67,14 @@ end if;
         inner join pg_catalog.pg_attribute a on (k.oid operator(pg_catalog.=) a.attrelid)
         inner join pg_catalog.pg_type y on (a.atttypid operator(pg_catalog.=) y.oid)
     where n.nspname operator(pg_catalog.=) source_schema
-      and k.relname operator(pg_catalog.=) source_table
-      and a.attnum operator(pg_catalog.>) 0
-      and a.attname operator(pg_catalog.=) _column_name
-      and y.typname in ('text', 'varchar', 'char', 'bpchar', 'bytea')
-    ;
+        and k.relname operator(pg_catalog.=) source_table
+        and a.attnum operator(pg_catalog.>) 0
+        and a.attname operator(pg_catalog.=) _column_name
+        and y.typname in ('text', 'varchar', 'char', 'bpchar', 'bytea');
+
     if not _found then
             raise exception 'column_name in config does not exist in the table: %', _column_name;
     end if;
-
 end
 $func$ language plpgsql stable security invoker
 set search_path to pg_catalog, pg_temp

--- a/projects/extension/sql/idempotent/014-parsing.sql
+++ b/projects/extension/sql/idempotent/014-parsing.sql
@@ -41,12 +41,12 @@ create or replace function ai._validate_parsing
 ) returns void
 as $func$
 declare
-    _parsing_config pg_catalog.jsonb;
-    _loading_config pg_catalog.jsonb;
-    _config_type pg_catalog.text;
-    _implementation pg_catalog.text;
-    _loading_implementation pg_catalog.text;
     _column_type pg_catalog.text;
+    _config_type pg_catalog.text;
+    _loading_config pg_catalog.jsonb;
+    _loading_implementation pg_catalog.text;
+    _parsing_config pg_catalog.jsonb;
+    _parsing_implementation pg_catalog.text;
 begin
     -- Get the parsing and loading configs
     _parsing_config = config operator(pg_catalog.->) 'parsing';
@@ -64,10 +64,8 @@ begin
     end if;
 
     -- Get implementations
-    _implementation = _parsing_config operator(pg_catalog.->>) 'implementation';
-    _loading_implementation = _loading_config operator(pg_catalog.->>) 'implementation';
-
-    if _implementation is null then
+    _parsing_implementation = _parsing_config operator(pg_catalog.->>) 'implementation';
+    if _parsing_implementation is null then
         raise exception 'invalid parsing config implementation';
     end if;
 
@@ -75,25 +73,25 @@ begin
     select y.typname 
     into _column_type
     from pg_catalog.pg_class k
-    inner join pg_catalog.pg_namespace n on (k.relnamespace operator(pg_catalog.=) n.oid)
-    inner join pg_catalog.pg_attribute a on (k.oid operator(pg_catalog.=) a.attrelid)
-    inner join pg_catalog.pg_type y on (a.atttypid operator(pg_catalog.=) y.oid)
+        inner join pg_catalog.pg_namespace n on (k.relnamespace operator(pg_catalog.=) n.oid)
+        inner join pg_catalog.pg_attribute a on (k.oid operator(pg_catalog.=) a.attrelid)
+        inner join pg_catalog.pg_type y on (a.atttypid operator(pg_catalog.=) y.oid)
     where n.nspname operator(pg_catalog.=) (config operator(pg_catalog.->>) 'source_schema')
     and k.relname operator(pg_catalog.=) (config operator(pg_catalog.->>) 'source_table')
     and a.attnum operator(pg_catalog.>) 0
     and a.attname operator(pg_catalog.=) (_loading_config operator(pg_catalog.->>) 'column_name');
 
     -- Validate all combinations
-    if _implementation = 'none' and _column_type = 'bytea' then
+    if _parsing_implementation = 'none' and _column_type = 'bytea' then
         raise exception 'cannot use parsing_none with bytea columns';
     end if;
 
-    if _loading_implementation = 'document' and _implementation = 'none' then
+    _loading_implementation = _loading_config operator(pg_catalog.->>) 'implementation';
+    if _loading_implementation = 'document' and _parsing_implementation = 'none' then
         raise exception 'cannot use parsing_none with document loading';
     end if;
 
-    if _implementation = 'pymupdf' 
-       and _loading_implementation = 'row' 
+    if _parsing_implementation = 'pymupdf' and _loading_implementation = 'row'
        and _column_type in ('text', 'varchar', 'char', 'bpchar') then
         raise exception 'cannot use parsing_pymupdf with text columns';
     end if;

--- a/projects/extension/sql/incremental/017-migrate-vectorizer-queue-tables.sql
+++ b/projects/extension/sql/incremental/017-migrate-vectorizer-queue-tables.sql
@@ -1,0 +1,24 @@
+do language plpgsql $block$
+declare
+    _rec pg_catalog.record;
+    _sql pg_catalog.text;
+begin
+    -- loop through all vectorizers to extract queue tables information
+    for _rec in (
+        select queue_schema, queue_table from ai.vectorizer
+    )
+    loop
+
+        select pg_catalog.format
+               ( $sql$alter table %I.%I
+                 add column if not exists retries pg_catalog.int4 default 0
+                 , add column if not exists retry_after pg_catalog.timestamptz default null$sql$
+                 , _rec.queue_schema
+                 , _rec.queue_table
+               ) into strict _sql;
+
+        raise debug '%', _sql;
+        execute _sql;
+    end loop;
+end;
+$block$;

--- a/projects/extension/tests/upgrade/test_upgrade.py
+++ b/projects/extension/tests/upgrade/test_upgrade.py
@@ -85,7 +85,7 @@ def check_version(
             return cur.fetchone()[0]
 
 
-def run_db_script(dbname: str, script: str) -> None:
+def init_db_script(dbname: str, script: str) -> None:
     cmd = " ".join(
         [
             "psql",
@@ -141,15 +141,15 @@ def test_upgrades():
         assert check_version("upgrade_target") == path.target
         # executes different init functions due to chunking function signature change.
         if is_version_earlier_than(path.target, "0.8.1"):
-            run_db_script("upgrade_target", "init_old.sql")
+            init_db_script("upgrade_target", "init_old.sql")
         else:
-            run_db_script("upgrade_target", "init.sql")
+            init_db_script("upgrade_target", "init.sql")
         snapshot("upgrade_target", f"{path_name}-expected")
         # start at the first version in the path
         create_database("upgrade_path")
         create_extension("upgrade_path", path.path[0])
         assert check_version("upgrade_path") == path.path[0]
-        run_db_script("upgrade_path", "init_old.sql")
+        init_db_script("upgrade_path", "init_old.sql")
         # upgrade through each version to the end
         for version in path.path[1:]:
             update_extension("upgrade_path", version)
@@ -210,7 +210,7 @@ def test_production_version_upgrade_path():
     # start at the first version
     create_extension("upgrade0", versions[0])
     assert check_version("upgrade0") == versions[0]
-    run_db_script("upgrade0", "init_old.sql")
+    init_db_script("upgrade0", "init_old.sql")
     # upgrade through each version to the end
     for version in versions[1:]:
         update_extension("upgrade0", version)
@@ -221,7 +221,7 @@ def test_production_version_upgrade_path():
     create_database("upgrade1")
     create_extension("upgrade1", versions[-1])
     assert check_version("upgrade1") == versions[-1]
-    run_db_script("upgrade1", "init_old.sql")
+    init_db_script("upgrade1", "init_old.sql")
     # snapshot the ai extension and schema
     snapshot("upgrade1", "upgrade1")
     # compare the snapshots. they should match

--- a/projects/extension/tests/vectorizer/test_vectorizer.py
+++ b/projects/extension/tests/vectorizer/test_vectorizer.py
@@ -137,12 +137,14 @@ Access method: heap
 
 
 QUEUE_TABLE = """
-                                                 Table "ai._vectorizer_q_1"
-  Column   |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
- title     | text                     |           | not null |         | extended |             |              | 
- published | timestamp with time zone |           | not null |         | plain    |             |              | 
- queued_at | timestamp with time zone |           | not null | now()   | plain    |             |              | 
+                                                  Table "ai._vectorizer_q_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+-------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ title       | text                     |           | not null |         | extended |             |              | 
+ published   | timestamp with time zone |           | not null |         | plain    |             |              | 
+ queued_at   | timestamp with time zone |           | not null | now()   | plain    |             |              | 
+ retries     | integer                  |           |          | 0       | plain    |             |              | 
+ retry_after | timestamp with time zone |           |          |         | plain    |             |              | 
 Indexes:
     "_vectorizer_q_1_title_published_idx" btree (title, published)
 Access method: heap

--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -236,6 +236,7 @@ class VectorizerQueryBuilder:
                 WITH selected_rows AS (
                     SELECT {pk_fields}
                     FROM {queue_table}
+                    WHERE retry_after is null or retry_after < now()
                     LIMIT %s
                     FOR UPDATE SKIP LOCKED
                 ),


### PR DESCRIPTION
As agreed in the design of the s3 document support, we're including retries and retry_after fields in the queue tables generated for each vectorizer.

Also add a couple of minor changes, rename func used in upgrades, and of vars of the loading migration.