### PR TITLE
fix: argument types to ai.render_sample tool

### DIFF
--- a/projects/extension/ai/semantic_catalog.py
+++ b/projects/extension/ai/semantic_catalog.py
@@ -9,8 +9,13 @@ class GeneratedDescription(TypedDict):
 
 
 def render_sample(plpy, relation: str, total: int = 5) -> str:
+    """
+    Given a table ore view name, return a sample of rows from it.
+    """
     ident = ".".join([plpy.quote_ident(part) for part in relation.split(".")])
-    result = plpy.execute(f"select * from {ident}", total)
+    # do not let LLM select 0 or less and no more than 10 rows, so as to not overwhelm
+    # context window.
+    result = plpy.execute(f"select * from {ident}", min(max(total, 1), 10))
 
     ret_obj = f"""<data id="{relation}">"""
     for r in result:

--- a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
+++ b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
@@ -325,7 +325,7 @@ begin
                         },
                         "total": {
                             "type": "integer",
-                            "description": "The total number of rows to return in the sample."
+                            "description": "The total number of rows to return in the sample, the max is 10."
                         }
                     },
                     "required": ["name", "total"]
@@ -408,7 +408,7 @@ begin
                             ;
                         when 'request_table_sample' then
                             raise debug 'tool use: request_table_sample';
-                            select _samples || jsonb_build_object(_message.input->'name', ai.render_sample(_message.input->'name', _message.input->'total'))
+                            select _samples || jsonb_build_object(_message.input->>'name', ai.render_sample((_message.input->>'name')::regclass, (_message.input->>'total')::int4))
                             into strict _samples
                             ;
                         when 'answer_user_question_with_sql_statement' then

--- a/projects/extension/sql/idempotent/908-text-to-sql-openai.sql
+++ b/projects/extension/sql/idempotent/908-text-to-sql-openai.sql
@@ -317,7 +317,7 @@ begin
                             },
                             "total": {
                                 "type": "integer",
-                                "description": "The total number of rows to return in the sample."
+                                "description": "The total number of rows to return in the sample, the max is 10."
                             }
                         },
                         "required": ["name", "total"]
@@ -425,7 +425,7 @@ begin
                         ;
                     when 'request_table_sample' then
                         raise debug 'tool use: request_table_sample';
-                        select _samples || jsonb_build_object(_tool_call.arguments->'name', ai.render_sample(_tool_call.arguments->'name', _tool_call.arguments->'total'))
+                        select _samples || jsonb_build_object(_tool_call.arguments->>'name', ai.render_sample((_tool_call.arguments->>'name')::regclass, (_tool_call.arguments->>'total')::int4))
                         into strict _samples
                         ;
                     when 'answer_user_question_with_sql_statement' then


### PR DESCRIPTION
PR fixes the types of the arguments that were being passed to the `ai.render_sample` function by the `request_table_sample`. To help force the LLM to call the tool to validate the fix, I made the following change to the prompt:

```diff
diff --git a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
index c24f228..240f9ef 100644
--- a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
+++ b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
@@ -14,6 +14,7 @@ as $func$
     ( E'\n'
     , $$Below are descriptions of database objects and examples of SQL statements that are meant to give context to a user's question.$$
     , $$Analyze the context provided. Identify the elements that are relevant to the user's question.$$
+    , $$If no <data> elements exist, you must call the "request_table_sample" tool to get a sample of the table data that you think is relevant.$$
     , $$If enough context has been provided to confidently address the question, use the "answer_user_question_with_sql_statement" tool to record your final answer in the form of a valid SQL statement.$$
     , E'\n'
     , coalesce(obj_prompt, '')

```