### PR TITLE
fix(text-to-sql): specify need fully qualified name for sample

### DIFF
--- a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
+++ b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
@@ -322,7 +322,7 @@ begin
                     "properties": {
                         "name": {
                             "type": "string",
-                            "description": "The name of the table or view to sample."
+                            "description": "The fully qualified `schema.name` of the table or view to sample."
                         },
                         "total": {
                             "type": "integer",
@@ -408,7 +408,7 @@ begin
                             into strict _questions
                             ;
                         when 'request_table_sample' then
-                            raise debug 'tool use: request_table_sample';
+                            raise debug 'tool use: request_table_sample: %', _message.input;
                             select _samples || jsonb_build_object(_message.input->>'name', ai.render_sample((_message.input->>'name')::regclass, (_message.input->>'total')::int4))
                             into strict _samples
                             ;

--- a/projects/extension/sql/idempotent/908-text-to-sql-openai.sql
+++ b/projects/extension/sql/idempotent/908-text-to-sql-openai.sql
@@ -313,7 +313,7 @@ begin
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "description": "The name of the table or view to sample."
+                                "description": "The fully qualified `schema.name` of the table or view to sample."
                             },
                             "total": {
                                 "type": "integer",
@@ -424,7 +424,7 @@ begin
                         into strict _questions
                         ;
                     when 'request_table_sample' then
-                        raise debug 'tool use: request_table_sample';
+                        raise debug 'tool use: request_table_sample: %', _tool_call.arguments;
                         select _samples || jsonb_build_object(_tool_call.arguments->>'name', ai.render_sample((_tool_call.arguments->>'name')::regclass, (_tool_call.arguments->>'total')::int4))
                         into strict _samples
                         ;


### PR DESCRIPTION
PR updates the tool description for `request_table_sample` that it requires a fully qualified `schema.name` to be passed in, which fixes an error where if it omits the schema, then the `::regclass` cast fails due to the `search_path` not including `public` on the function.

I think it'd be good to do this, in addition to potential search path updates that @jgpruitt is working for the potential case of multi-schema DB setups that people are working over.