### PR TITLE
feat(text_to_sql): add a func to resolve ambiguous object references

### DIFF
--- a/projects/extension/ai/semantic_catalog.py
+++ b/projects/extension/ai/semantic_catalog.py
@@ -8,16 +8,15 @@ class GeneratedDescription(TypedDict):
     description: str
 
 
-def render_sample(plpy, relation: str, total: int = 5) -> str:
+def render_sample(plpy, fq_relation: str, total: int = 5) -> str:
     """
     Given a table ore view name, return a sample of rows from it.
     """
-    ident = ".".join([plpy.quote_ident(part) for part in relation.split(".")])
     # do not let LLM select 0 or less and no more than 10 rows, so as to not overwhelm
     # context window.
-    result = plpy.execute(f"select * from {ident}", min(max(total, 1), 10))
+    result = plpy.execute(f"select * from {fq_relation}", min(max(total, 1), 10))
 
-    ret_obj = f"""<data id="{relation}">"""
+    ret_obj = f"""<data id="{fq_relation}">"""
     for r in result:
         values = []
         for v in r.values():
@@ -27,9 +26,8 @@ def render_sample(plpy, relation: str, total: int = 5) -> str:
                 values.append("true" if v else "false")
             else:
                 values.append(str(v))
-        ret_obj += f"""\n  insert into {ident} ({', '.join(plpy.quote_ident(key) for key in r.keys())}) values ({', '.join(values)});"""
+        ret_obj += f"""\n  insert into {fq_relation} ({', '.join(plpy.quote_ident(key) for key in r.keys())}) values ({', '.join(values)});"""
     ret_obj += "\n</data>"
-
     return ret_obj
 
 

--- a/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
+++ b/projects/extension/sql/idempotent/906-text-to-sql-anthropic.sql
@@ -88,6 +88,7 @@ create function ai._text_to_sql_anthropic
 ( question text
 , catalog_name text default 'default'
 , config jsonb default null
+, search_path text default pg_catalog.current_setting('search_path', true)
 ) returns jsonb
 as $func$
 declare
@@ -409,7 +410,14 @@ begin
                             ;
                         when 'request_table_sample' then
                             raise debug 'tool use: request_table_sample: %', _message.input;
-                            select _samples || jsonb_build_object(_message.input->>'name', ai.render_sample((_message.input->>'name')::regclass, (_message.input->>'total')::int4))
+                            select _samples || jsonb_build_object
+                            ( _message.input->>'name'
+                            , ai.render_sample
+                              ( (_message.input->>'name')
+                              , (_message.input->>'total')::int4
+                              , search_path
+                              )
+                            )
                             into strict _samples
                             ;
                         when 'answer_user_question_with_sql_statement' then

--- a/projects/extension/sql/idempotent/907-text-to-sql-ollama.sql
+++ b/projects/extension/sql/idempotent/907-text-to-sql-ollama.sql
@@ -41,6 +41,7 @@ create function ai._text_to_sql_ollama
 ( question text
 , catalog_name text default 'default'
 , config jsonb default null
+, search_path text default pg_catalog.current_setting('search_path', true)
 ) returns jsonb
 as $func$
 declare

--- a/projects/extension/sql/idempotent/909-text-to-sql-cohere.sql
+++ b/projects/extension/sql/idempotent/909-text-to-sql-cohere.sql
@@ -57,6 +57,7 @@ create function ai._text_to_sql_cohere
 ( question text
 , catalog_name text default 'default'
 , config jsonb default null
+, search_path text default pg_catalog.current_setting('search_path', true)
 ) returns jsonb
 as $func$
 declare

--- a/projects/extension/sql/idempotent/910-text-to-sql.sql
+++ b/projects/extension/sql/idempotent/910-text-to-sql.sql
@@ -6,6 +6,7 @@ create function ai._text_to_sql
 ( question text
 , catalog_name text default 'default'
 , config jsonb default null
+, search_path text default pg_catalog.current_setting('search_path', true)
 ) returns jsonb
 as $func$
 declare
@@ -25,24 +26,28 @@ begin
             ( question
             , catalog_name
             , config
+            , search_path
             );
         when 'ollama' then
             _result = ai._text_to_sql_ollama
             ( question
             , catalog_name
             , config
+            , search_path
             );
         when 'openai' then
             _result = ai._text_to_sql_openai
             ( question
             , catalog_name
             , config
+            , search_path
             );
         when 'cohere' then
             _result = ai._text_to_sql_cohere
             ( question
             , catalog_name
             , config
+            , search_path
             );
         else
             raise exception 'text-to-sql provider % not recognized', config->>'provider';
@@ -59,6 +64,7 @@ create function ai.text_to_sql
 ( question text
 , catalog_name text default 'default'
 , config jsonb default null
+, search_path text default pg_catalog.current_setting('search_path', true)
 ) returns text
 as $func$
 declare
@@ -68,6 +74,7 @@ begin
     ( question
     , catalog_name
     , config
+    , search_path
     );
     if _result is not null then
         return _result->>'sql_statement';


### PR DESCRIPTION
Adds a func to resolve ambiguous object references.

We need the user's search_path to make sampling table rows and running EXPLAIN work when the database objects are not fully-qualified. So, we capture it and pass it down.