### PR TITLE
test(openai): do not check content length when stopped for max tokens

### DIFF
--- a/projects/extension/tests/test_openai.py
+++ b/projects/extension/tests/test_openai.py
@@ -257,7 +257,7 @@ def test_openai_chat_complete_with_tokens_limitation_on_reasoning_models(
 
         if stopped:
             assert finish_reason == "length"
-            assert len(content) == 0
+            # assert len(content) == 0 have experienced issues with this line. sometimes content is returned
         else:
             assert len(content) > 0
 


### PR DESCRIPTION
The test_openai_chat_complete_with_tokens_limitation_on_reasoning_models test is failing randomly. Sometimes the LLM returns content when it is stopped for length reasons. Sometimes it doesn't. Drop the assertion.