### PR TITLE
fix: max_tokens_per_request error when pushing many documents at once

### DIFF
--- a/projects/pgai/pgai/vectorizer/embedders/openai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/openai.py
@@ -69,6 +69,11 @@ class OpenAI(ApiKeyMixin, BaseURLMixin, BaseModel, Embedder):
     def _max_chunks_per_batch(self) -> int:
         return 2048
 
+    @override
+    def _max_tokens_per_batch(self) -> int|None:
+        # See https://github.com/timescale/pgai/pull/482#issuecomment-2659799567
+        return 600_000
+
     async def call_embed_api(self, documents: list[Document]) -> EmbeddingResponse:
         response = await self._embedder.create(
             input=cast(list[str] | Iterable[Iterable[int]], documents),
@@ -89,7 +94,7 @@ class OpenAI(ApiKeyMixin, BaseURLMixin, BaseModel, Embedder):
     def _batcher(self) -> BatchApiCaller[Document]:
         return BatchApiCaller(
             self._max_chunks_per_batch(),
-            600_000, # See https://github.com/timescale/pgai/pull/482#issuecomment-2659799567
+            self._max_tokens_per_batch(),
             self.call_embed_api,
             self._encoder,
         )

--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -55,7 +55,7 @@ T = TypeVar("T", StringDocument, TokenDocument, Document)
 @dataclass
 class BatchApiCaller(Generic[T]):
     max_chunks_per_batch: int
-    max_tokens_per_batch: int
+    max_tokens_per_batch: int|None
     api_callable: Callable[[list[T]], Awaitable[EmbeddingResponse]]
     encoder: tiktoken.Encoding | None
 
@@ -74,7 +74,7 @@ class BatchApiCaller(Generic[T]):
         max_chunks_per_batch = self.max_chunks_per_batch
         num_of_batches = math.ceil(len(documents) / max_chunks_per_batch)
 
-        if self.max_tokens_per_batch and self.encoder is not None:
+        if self.max_tokens_per_batch is not None and self.encoder is not None:
             for i in range(0, len(documents), max_chunks_per_batch):
                 batch = documents[i : i + max_chunks_per_batch]
                 tokens_this_batch = 0
@@ -182,6 +182,14 @@ class Embedder(ABC):
         The maximum number of chunks that can be embedded per API call
         :return: int: the max chunk count
         """
+
+    def _max_tokens_per_batch(self) -> int|None:
+        """
+        The maximum number of tokens a batch can contain. If the
+        batch contains more tokens than this, it will be split into multiple.
+        :return: int: the max token count
+        """
+        return None
 
     async def setup(self) -> None:  # noqa: B027 empty on purpose
         """


### PR DESCRIPTION
Resolves https://github.com/timescale/pgai/issues/481

This is the easiest solution I could come up with, but it might not be the most elegant. Ideally, we would know in advance the max number of tokens and make sure the batch does not exceed that. I haven't found a way to get that information using OpenAI's api though, but we could think about parsing the error response and then using that in following requests.