### PR TITLE
fix(vectorizer): use sql name for data types in source_pk

### DIFF
--- a/projects/extension/sql/idempotent/012-vectorizer-int.sql
+++ b/projects/extension/sql/idempotent/012-vectorizer-int.sql
@@ -6,7 +6,7 @@ $func$
     select pg_catalog.jsonb_agg(x)
     from
     (
-        select e.attnum, e.pknum, a.attname, y.typname
+        select e.attnum, e.pknum, a.attname, pg_catalog.format_type(y.oid, a.atttypmod) as typname
         from pg_catalog.pg_constraint k
         cross join lateral pg_catalog.unnest(k.conkey) with ordinality e(attnum, pknum)
         inner join pg_catalog.pg_attribute a

--- a/projects/extension/sql/incremental/017-upgrade-vec-source-pk.sql
+++ b/projects/extension/sql/incremental/017-upgrade-vec-source-pk.sql
@@ -1,0 +1,65 @@
+
+do language plpgsql $block$
+declare
+    _vec ai.vectorizer;
+    _version text;
+    _parts text[];
+    _source_pk jsonb;
+    _source regclass;
+begin
+    -- loop over all vectorizers
+    for _vec in (select * from ai.vectorizer)
+    loop
+        -- if the vectorizer was created at or before 0.8.0 we need to upgrade it
+        -- this version check is likely not necessary since this is an incremental migration
+        -- but i'm being extra paranoid
+        _version = _vec.config operator(pg_catalog.->>) 'version';
+        _parts = regexp_split_to_array(_version, '[.\-]');
+        if _parts[1]::int4 > 0 then -- major
+            continue;
+        end if;
+        if _parts[2]::int4 > 8 then -- minor
+            continue;
+        end if;
+        if _parts[2]::int4 = 8 and _parts[3]::int4 > 0 then -- patch
+            continue;
+        end if;
+        
+        -- look up the source table
+        _source = pg_catalog.to_regclass
+        ( pg_catalog.format
+          ( '%I.%I'
+          , _vec.source_schema
+          , _vec.source_table
+          )
+        );
+        if _source is null then
+            continue;
+        end if;
+        
+        -- reconstruct the primary key info with the fix for typname
+        select pg_catalog.jsonb_agg(x) into _source_pk
+        from
+        (
+            select e.attnum, e.pknum, a.attname, pg_catalog.format_type(y.oid, a.atttypmod) as typname
+            from pg_catalog.pg_constraint k
+            cross join lateral pg_catalog.unnest(k.conkey) with ordinality e(attnum, pknum)
+            inner join pg_catalog.pg_attribute a
+                on (k.conrelid operator(pg_catalog.=) a.attrelid
+                    and e.attnum operator(pg_catalog.=) a.attnum)
+            inner join pg_catalog.pg_type y on (a.atttypid operator(pg_catalog.=) y.oid)
+            where k.conrelid operator(pg_catalog.=) _source
+            and k.contype operator(pg_catalog.=) 'p'
+        ) x
+        ;
+        if _source_pk is null then
+            continue;
+        end if;
+        
+        -- update the row
+        update ai.vectorizer v set source_pk = _source_pk
+        where v.id = _vec.id
+        ;
+    end loop;
+end;
+$block$;


### PR DESCRIPTION
pg_type.typname works fine in SQL but chokes up psycopg3. Use pg_catalog.format_type to get the SQL name of a type instead.

1. create a source table with a primary key with an array type e.g. text[]
2. the `typname` from `pg_type` will be `_text`
3. SQL seems to handle `_text` fine as if it were an alias to `text[]`
4. `format_type()` will translate this back to `text[]`
5. the vectorizer worker is using the binary copy format and has to call `set_types(...)` in psycopg3
6. psycopg3 barfs all over `_text`. doesn't know what it is
7. psycopg3 does recognize `text[]`


- `pg_type.typname` is not unique. `typname` + `typnamespace` is unique
- We didn't have enough information in the original implementation of source_pk to identify a type uniquely
- The original implementation would fail if a type is defined in a schema off the search_path
- Using `format_type()` gives us the type in SQL parlance with schema if necessary
