### PR TITLE
feat: add litellm to alembic and python vectorizer creation

### DIFF
--- a/projects/pgai/pgai/vectorizer/configuration.py
+++ b/projects/pgai/pgai/vectorizer/configuration.py
@@ -70,6 +70,19 @@ class ChunkingRecursiveCharacterTextSplitterConfig(SQLArgumentMixin):
 
 
 @dataclass
+class EmbeddingLitellmConfig(SQLArgumentMixin):
+    """Configuration for ai.embedding_litellm function."""
+
+    arg_type: ClassVar[str] = "embedding"
+    function_name: ClassVar[str] = "ai.embedding_litellm"
+
+    model: str
+    dimensions: int
+    api_key_name: str | None = None
+    extra_options: dict[str, Any] | None = None
+
+
+@dataclass
 class EmbeddingOllamaConfig(SQLArgumentMixin):
     """Configuration for ai.embedding_ollama function."""
 
@@ -94,6 +107,7 @@ class EmbeddingOpenaiConfig(SQLArgumentMixin):
     dimensions: int
     chat_user: str | None = None
     api_key_name: str | None = None
+    base_url: str | None = None
 
 
 @dataclass

--- a/projects/pgai/pgai/vectorizer/create_vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/create_vectorizer.py
@@ -8,6 +8,7 @@ from typing import Any
 from .configuration import (
     ChunkingCharacterTextSplitterConfig,
     ChunkingRecursiveCharacterTextSplitterConfig,
+    EmbeddingLitellmConfig,
     EmbeddingOllamaConfig,
     EmbeddingOpenaiConfig,
     EmbeddingVoyageaiConfig,
@@ -31,7 +32,11 @@ class CreateVectorizer:
     source: str
     destination: str | None = None
     embedding: (
-        EmbeddingOllamaConfig | EmbeddingOpenaiConfig | EmbeddingVoyageaiConfig | None
+        EmbeddingLitellmConfig
+        | EmbeddingOllamaConfig
+        | EmbeddingOpenaiConfig
+        | EmbeddingVoyageaiConfig
+        | None
     ) = None
     chunking: (
         ChunkingCharacterTextSplitterConfig

--- a/projects/pgai/pgai/vectorizer/generate/docker-compose.yaml
+++ b/projects/pgai/pgai/vectorizer/generate/docker-compose.yaml
@@ -1,7 +1,10 @@
 name: pgai
 services:
   db:
-    image: timescale/timescaledb-ha:pg17
+    build:
+      context: ../../../../extension
+      dockerfile: Dockerfile
+      target: pgai-test-db
     environment:
       POSTGRES_PASSWORD: postgres
     ports:

--- a/projects/pgai/pgai/vectorizer/generate/generate.py
+++ b/projects/pgai/pgai/vectorizer/generate/generate.py
@@ -15,6 +15,7 @@ VECTORIZER_FUNCTIONS = [
     "embedding_openai",
     "embedding_ollama",
     "embedding_voyageai",
+    "embedding_litellm",
     "chunking_character_text_splitter",
     "chunking_recursive_character_text_splitter",
     "formatting_python_template",
@@ -50,6 +51,7 @@ def generate_vectorizer_configs(
 ) -> None:
     """Generate all vectorizer configuration classes."""
     with psycopg.connect(conn_str) as conn:
+        conn.execute("Create extension if not exists ai cascade;")
         available_functions = list_vectorizer_functions(conn)
         functions = get_function_metadata(conn, available_functions)
         generate_config_classes(functions, output_file)


### PR DESCRIPTION
In the merge race when litellm and sqlalchemy/alembic was merged we forgot to regenerate the config classes, so did that now.