### PR TITLE
chore: ignore errors when removing dist-info dir

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -170,7 +170,7 @@ class Actions:
             for d in version_target_dir.glob(
                 "pgai-*.dist-info"
             ):  # delete package info if exists
-                shutil.rmtree(d)
+                shutil.rmtree(d, ignore_errors=True)
             bin = "pip3" if shutil.which("uv") is None else "uv pip"
             cmd = f'{bin} install -v --no-deps --compile --target "{version_target_dir}" "{ext_dir()}"'
             subprocess.run(


### PR DESCRIPTION
## Description

This change ignore errors when removing package info files during install. For some reason, this is failing randomly in CI with:

```
error: failed to remove directory `/pgai/.venv/lib/python3.11/site-packages/pgai-0.8.1.dev0.dist-info`: No such file or directory (os error 2)
Traceback (most recent call last):
  File "/pgai/./build.py", line 9[17](https://github.com/timescale/pgai/actions/runs/13387786312/job/37388315675?pr=442#step:14:18), in <module>
    fn()
  File "/pgai/./build.py", line 316, in test
    subprocess.run(
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'uv run pytest' returned non-zero exit status 2.
```

This is not ideal, but it will improve Dev Ex by speeding up CI-building times avoiding re-scheduling builds.