### PR TITLE
fix(build): use --no-project flag to uv run for build tasks

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -314,7 +314,11 @@ class Actions:
     def test() -> None:
         """runs the tests in the docker container"""
         subprocess.run(
-            "uv run pytest", shell=True, check=True, env=os.environ, cwd=tests_dir()
+            "uv run --no-project pytest",
+            shell=True,
+            check=True,
+            env=os.environ,
+            cwd=tests_dir(),
         )
 
     @staticmethod
@@ -324,7 +328,7 @@ class Actions:
             cmd = "docker exec -it -w /pgai/tests/vectorizer pgai-ext fastapi dev server.py"
             subprocess.run(cmd, shell=True, check=True, env=os.environ, cwd=ext_dir())
         else:
-            cmd = "uv run fastapi dev server.py"
+            cmd = "uv run --no-project fastapi dev server.py"
             subprocess.run(
                 cmd,
                 shell=True,
@@ -349,7 +353,10 @@ class Actions:
     def lint_py() -> None:
         """runs ruff linter against the python source files"""
         subprocess.run(
-            f"uv run ruff check {ext_dir()}", shell=True, check=True, env=os.environ
+            f"uv run --no-project ruff check {ext_dir()}",
+            shell=True,
+            check=True,
+            env=os.environ,
         )
 
     @staticmethod
@@ -362,7 +369,7 @@ class Actions:
     def format_py() -> None:
         """runs ruff to check formatting of the python source files"""
         subprocess.run(
-            f"uv run ruff format --diff {ext_dir()}",
+            f"uv run --no-project ruff format --diff {ext_dir()}",
             shell=True,
             check=True,
             env=os.environ,
@@ -372,7 +379,10 @@ class Actions:
     def reformat_py() -> None:
         """runs ruff to update the formatting of the python source files"""
         subprocess.run(
-            f"ruff format {ext_dir()}", shell=True, check=True, env=os.environ
+            f"uv run --no-project ruff format {ext_dir()}",
+            shell=True,
+            check=True,
+            env=os.environ,
         )
 
     @staticmethod


### PR DESCRIPTION
This PR addresses the bug below that we have been experiencing frequently in CI. When we use `uv run` to run tasks in CI, those tasks do NOT depend on the pgai project being installed. It seems `uv run` will install the pgai package by default since we are running `uv run` in a directory with a pyproject.toml. This PR adds the `--no-project` flag to `uv run` to avoid this behavior.

https://docs.astral.sh/uv/guides/scripts/#running-a-script-without-dependencies

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/4bc9f775-352b-4976-b613-7c6d55bb2185" />
