### PR TITLE
fix: load target column types' oids to use in binary copy cmd

### DIFF
--- a/projects/pgai/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer.py
@@ -140,3 +140,94 @@ def test_vectorizer_internal():
         )
         actual = cur.fetchone()[0]  # type: ignore
         assert actual is True
+
+
+def test_vectorizer_weird_pk():
+    # make sure we can handle a multi-column primary key with "interesting" data types
+    # this has implications on the COPY with binary format logic in the vectorizer
+    db = "vcli1"
+    create_database(db)
+    _db_url = db_url("postgres", db)
+    with (
+        psycopg.connect(_db_url, autocommit=True, row_factory=namedtuple_row) as con,
+        con.cursor() as cur,
+    ):
+        cur.execute("create extension if not exists vectorscale cascade")
+        cur.execute("create extension if not exists timescaledb")
+        cur.execute("create extension if not exists ai cascade")
+        pgai_version = cli.get_pgai_version(cur)
+        assert pgai_version is not None
+        cur.execute("drop table if exists weird")
+        cur.execute("""
+                create table weird
+                ( a text[] not null
+                , b varchar(3) not null
+                , c timestamp with time zone not null
+                , d tstzrange not null
+                , note text not null
+                , primary key (a, b, c, d)
+                )
+            """)
+        # create a vectorizer for the table
+        cur.execute("""
+                select ai.create_vectorizer
+                ( 'weird'::regclass
+                , embedding=>ai.embedding_openai('text-embedding-3-small', 3)
+                , formatting=>ai.formatting_python_template('$chunk')
+                , chunking=>ai.chunking_character_text_splitter('note')
+                , scheduling=>
+                    ai.scheduling_timescaledb
+                    ( interval '5m'
+                    , initial_start=>'2050-01-06'::timestamptz
+                    , timezone=>'America/Chicago'
+                    )
+                , indexing=>ai.indexing_diskann(min_rows=>10)
+                , grant_to=>null
+                , enqueue_existing=>true
+                )
+            """)
+        row = cur.fetchone()
+        if row is None:
+            raise ValueError("vectorizer_id is None")
+        vectorizer_id = row[0]
+        if not isinstance(vectorizer_id, int):
+            raise ValueError("vectorizer_id is not an integer")
+
+        cur.execute("select * from ai.vectorizer where id = %s", (vectorizer_id,))
+        vectorizer_expected = cur.fetchone()
+
+        # test cli.get_vectorizer
+        vectorizer_actual = cli.get_vectorizer(_db_url, vectorizer_id)
+        assert vectorizer_actual is not None
+        assert vectorizer_expected.source_table == vectorizer_actual.source_table  # type: ignore
+
+        # insert 7 rows into source
+        cur.execute("""
+                insert into weird (a, b, c, d, note)
+                select
+                  array['larry', 'moe', 'curly']
+                , 'xyz'
+                , t
+                , tstzrange(t, t + interval '1d', '[)')
+                , 'if two witches watch two watches, which witch watches which watch'
+                from generate_series('2025-01-06'::timestamptz, '2025-01-12'::timestamptz, interval '1d') t
+            """)  # noqa
+
+        # run the vectorizer
+        features = Features(pgai_version)
+        cli.run_vectorizer(_db_url, vectorizer_actual, 1, features)
+
+        # make sure the queue was emptied
+        cur.execute("select ai.vectorizer_queue_pending(%s)", (vectorizer_id,))
+        actual = cur.fetchone()[0]  # type: ignore
+        assert actual == 0
+
+        # make sure we got 7 rows out
+        cur.execute(
+            SQL("select count(*) from {target_schema}.{target_table}").format(
+                target_schema=Identifier(vectorizer_expected.target_schema),  # type: ignore
+                target_table=Identifier(vectorizer_expected.target_table),  # type: ignore
+            )
+        )
+        actual = cur.fetchone()[0]  # type: ignore
+        assert actual == 7


### PR DESCRIPTION
We use the `COPY` command with the `BINARY` format in Vectorizer to load embeddings into the target table. To do so, we have to tell psycopg the types of the columns we are copying into. The `set_types` function can take type names or oids of types. We used type names but discovered this is incompatible with some types/domains we encountered.

This PR switches to using OIDs.

The pgai extension can continue to send types, but the vectorizer worker will ignore them. This is important as we need the worker to be backward-compatible with old extension versions. Instead, it will look up the OIDs of the types on the fly using the postgres catalog. It will do this once -- the first time it attempts to do a COPY.

I will do a follow-up PR to have the extension stop sending the type info.

https://www.psycopg.org/psycopg3/docs/api/copy.html#psycopg.Copy.set_types

This STILL does not work for EVERY type. I found that `bit(4)` did not work. psycopg loads a `bit(4)` into a Python str but will not support COPYing a str into a bit(4) via binary copy. Similarly, a `bpchar` type could not be loaded with pyscopg. To make these work, you must (possibly write) configure and register appropriate dumpers and loaders.

We need to think about how to enable the use of these types.

https://www.psycopg.org/psycopg3/docs/advanced/adapt.html