### PR TITLE
ci: add compose-dev.yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+*.env
 .idea
 .venv
 build

--- a/projects/pgai/compose-dev.yaml
+++ b/projects/pgai/compose-dev.yaml
@@ -1,0 +1,32 @@
+name: pgai
+services:
+  db:
+    build:
+      context: ../extension
+      dockerfile: Dockerfile
+      target: pgai-test-db
+    ports:
+      - "5432:5432"
+    volumes:
+      - data:/home/postgres/pgdata/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+    env_file:
+      - path: ./.env
+        required: false
+      - path: ./db.env
+        required: false
+  vectorizer-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
+    env_file:
+      - path: ./.env
+        required: false
+      - path: ./worker.env
+        required: false
+    command: [ "--poll-interval", "5s", "--log-level", "DEBUG" ]
+volumes:
+  data:


### PR DESCRIPTION
## Description

This PR adds a `compose-dev.yaml` file that any developer can use for running both the vectorizer-worker and an instance of postgres with the extension preloaded, all built from source.

I added a new section to the `DEVELOPMENT.md` file on pgai project with instructions on how to run it.