### PR TITLE
build(extension): remove tmp dir before cloning into it

### DIFF
--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -134,6 +134,7 @@ class Actions:
             if version_target_dir.exists():
                 continue
             tmp_dir = Path(tempfile.gettempdir()).joinpath("pgai", version)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
             tmp_dir.mkdir(parents=True, exist_ok=True)
             branch = git_tag(version)
             subprocess.run(


### PR DESCRIPTION
If you install and then uninstall and then try to install again (which I do during development), the second install will fail. We should delete the dir (if exists) we are cloning into before cloning into it.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/bc51b5e7-50f8-4786-acb6-5f01bd7e0084" />
