### PR TITLE
chore: allow docs to skip ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
 permissions:
   contents: read
 


### PR DESCRIPTION
removing as doc changes shouldn't have to run code tests.