### PR TITLE
ci: use pull_request_target for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  pull_request:
+  # pull_request_target means this workflow runs on the base branch, not the PR branch
+  pull_request_target:
     paths-ignore:
       - "**.md"
   workflow_dispatch:


### PR DESCRIPTION
Alternative to https://github.com/timescale/pgai/pull/518

- GH by defaults keeps asking maintainers to approve workflows for external contributions
- Means pull_request_target change should be enough for fixing the current issue.
- Environments would be an extra step of security if we want to use different env vars depending on the source of the contribution, otherwise are not needed
- Enforcing different kind of requirements to merge PR's based on the type of file (md or the rest) is not possible right directly withing gh config but with either
  - [this action](https://github.com/upsidr/merge-gatekeeper)
  - I believe we can just do the check ourselves and if the change is a markdown or not and fail accordingly