### PR TITLE
docs: fix broken links in markdown files

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -14,5 +14,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
+          args: --exclude-loopback --accept '403' .
           format: markdown
           jobSummary: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -129,5 +129,5 @@ You can then play around with the latest and greatest changes.
 [discord-server]: https://discord.gg/KRdHVXAmkp
 [just-gh]: https://github.com/casey/just
 [just-docs]: https://github.com/casey/just?tab=readme-ov-file#installation
-[uv-website]: https://uv.astral.sh
+[uv-website]: https://docs.astral.sh/uv/
 [uv-docs]: https://docs.astral.sh/uv/getting-started/installation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,4 +22,4 @@ Only use this e-mail address to report undisclosed security vulnerabilities in T
 
 Submit regular bug reports as [GitHub issues](https://github.com/timescale/pgai/issues), as _questions_ around security,
 compliance, or functionality through customer support or community channels such as 
-[Timescale Slack](https://slack.timescale.com/) and the [Forums](https://www.timescale.com/forums).
+[Timescale Slack](https://slack.timescale.com/) and the [Forums](https://www.timescale.com/forum/).

--- a/docs/model_calling/anthropic.md
+++ b/docs/model_calling/anthropic.md
@@ -227,7 +227,7 @@ Outputs:
 
 You can run this example of **tool_use** in your database to extract named
 entities from the given text input.
-The [extract_entities.sql](../examples/extract_entities.sql) is wrapping the
+The [extract_entities.sql](/examples/extract_entities.sql) is wrapping the
 function.
 
 ```sql
@@ -247,7 +247,7 @@ the named entities with their types.
 -[ RECORD 1 ]--+------------------------------------------------
 anonymize_text | :PERSON: works at :ORGANIZATION: in :LOCATION:.
 ```
-Through the same mechanism, the [summarize_article.sql](../examples/summarize_article.sql)
+Through the same mechanism, the [summarize_article.sql](/examples/summarize_article.sql)
 example shows how to extract structured json with the `summarize_article` tool.
 
 ```sql

--- a/docs/model_calling/moderate.md
+++ b/docs/model_calling/moderate.md
@@ -7,7 +7,7 @@ Let's say you want to moderate comments using OpenAI. You can do it in two ways:
 
 ## Via trigger
 
-You can get the full example in the [trigger_moderate.sql](examples/trigger_moderate.sql) file.
+You can get the full example in the [trigger_moderate.sql](/examples/trigger_moderate.sql) file.
 
 First, let's create the extension and set the API key:
 
@@ -114,10 +114,7 @@ id |          body           |         created_at         |   status
 Background options will not be blocking your transactions, so it's a better option for
 moderating comments in a production environment and for a large number of comments.
 
-Check out [background_actions.md](background_actions.md) for more information on
-how to setup background actions to use open ai keys properly.
-
-You can get the full example in the [bg_worker_moderate.sql](examples/bg_worker_moderate.sql).
+You can get the full example in the [bg_worker_moderate.sql](/examples/bg_worker_moderate.sql).
 
 For the background action, instead of the trigger, we will create a procedure
 that will moderate the comments:

--- a/docs/structured_retrieval/text_to_sql.md
+++ b/docs/structured_retrieval/text_to_sql.md
@@ -55,7 +55,7 @@ alter extension ai update;
 
 ## Create the semantic catalog
 
-This function creates [vectorizers](https://github.com/timescale/pgai/blob/main/docs/vectorizer/overview.md) for the tables that pgai uses to store descriptions for tables, columns, and queries. These vectorizers will automatically generate embeddings for the descriptions and update them if you edit the descriptions.
+This function creates [vectorizers](/docs/vectorizer/overview.md) for the tables that pgai uses to store descriptions for tables, columns, and queries. These vectorizers will automatically generate embeddings for the descriptions and update them if you edit the descriptions.
 
 For example:
 

--- a/docs/vectorizer/api-reference.md
+++ b/docs/vectorizer/api-reference.md
@@ -51,9 +51,6 @@ Vectorizer significantly simplifies the process of incorporating AI-powered
 semantic search and analysis capabilities into existing PostgreSQL databases.  
 Making it easier for you to leverage the power of LLMs in your data workflows.
 
-Vectorizers are available on [Timescale Cloud][timescale-cloud]. You can
-also run it yourself, please see the [Self Hosting Guide](TODO).
-
 Vectorizer offers the following APIs:
 
 **Create and configure vectorizers**

--- a/docs/vectorizer/python-integration.md
+++ b/docs/vectorizer/python-integration.md
@@ -1,7 +1,7 @@
 # Creating vectorizers from python
 
 To create a vectorizer from python you use the `CreateVectorizer` helper class from the `pgai.vectorizer` module.
-It accepts all the options listed in the [SQL API](vectorizer/api-reference.md) and exposes the `to_sql`
+It accepts all the options listed in the [SQL API](/docs/vectorizer/api-reference.md) and exposes the `to_sql`
 method to generate a SQL query which you can then run through the SQL library of your choice.
 
 First install the pgai library:
@@ -263,4 +263,4 @@ def downgrade() -> None:
     op.drop_vectorizer(target_table="blog_embeddings", drop_all=True)
 ```
 
-The `create_vectorizer` operation supports all configuration options available in the [SQL API](vectorizer/api-reference.md).
+The `create_vectorizer` operation supports all configuration options available in the [SQL API](/docs/vectorizer/api-reference.md).

--- a/docs/vectorizer/quick-start-voyage.md
+++ b/docs/vectorizer/quick-start-voyage.md
@@ -1,7 +1,7 @@
 # Vectorizer quick start with VoyageAI
 
 This page shows you how to create a vectorizer and run a semantic search on the automatically embedded data on a self-hosted Postgres instance.
-To follow this tutorial you need to have a Voyage AI account API key. You can get one [here](https://voyageai.com/).
+To follow this tutorial you need to have a Voyage AI account API key. You can get one [here](https://www.voyageai.com/).
 
 ## Setup a local development environment
 

--- a/docs/vectorizer/worker.md
+++ b/docs/vectorizer/worker.md
@@ -5,7 +5,7 @@ When you install pgai on Timescale Cloud or another cloud installation, you use
 scheduling to control the times when vectorizers are run. A scheduled job detects whether work is to be done for the 
 vectorizers. If there is, the job runs the cloud function to embed the data.
 
-When you have [defined vectorizers](./vectorizer.md#define-a-vectorizer) on a self-hosted Postgres installation, you 
+When you have [defined vectorizers](/docs/vectorizer/overview.md#define-a-vectorizer) on a self-hosted Postgres installation, you 
 use vectorizer worker to asynchronously processes them. By default, when you run `pgai vectorizer worker`, it 
 loops over the vectorizers defined in your database and processes each vectorizer in turn.
 
@@ -258,4 +258,4 @@ the following environment variables.
 [docker]: https://docs.docker.com/get-docker/
 [psql]: https://www.timescale.com/blog/how-to-install-psql-on-mac-ubuntu-debian-windows/
 [openai-key]: https://platform.openai.com/api-keys
-[voyage-key]: https://dash.voyageai.com/api-keys
+[voyage-key]: https://docs.voyageai.com/docs/faq#how-do-i-get-the-voyage-api-key

--- a/projects/extension/DEVELOPMENT.md
+++ b/projects/extension/DEVELOPMENT.md
@@ -107,7 +107,7 @@ To make changes to pgai:
 
 ## Controlling pgai extension tests
 
-The [projects/extension/tests](./projects/extension/tests) directory contains the unit tests.
+The [projects/extension/tests](/projects/extension/tests) directory contains the unit tests.
 
 To set up the tests:
 
@@ -131,14 +131,14 @@ To set up the tests:
    - **Cohere**:
       - `COHERE_API_KEY` - a [Cohere API Key](https://docs.cohere.com/docs/rate-limits) for Cohere unit testing.
    - **Voyage**:
-      - `VOYAGE_API_KEY` - a [Voyage API Key](https://voyageai.com) for Voyage unit testing.
+      - `VOYAGE_API_KEY` - a [Voyage API Key](https://www.voyageai.com/) for Voyage unit testing.
 
    Providing these keys automatically enables the corresponding tests.
 
 ## Dependency management in the pgai extension
 
 The pgai extension uses `uv` for dependency management. Dependencies are listed
-in the [pyproject.toml](./projects/extension/pyproject.toml) file.
+in the [pyproject.toml](/projects/extension/pyproject.toml) file.
 uv is already installed in the development docker container. To use it in your
 local environment, follow uv's [installation instructions](https://github.com/astral-sh/uv#installation).
 
@@ -157,7 +157,7 @@ local environment, follow uv's [installation instructions](https://github.com/as
 
 ## The pgai extension architecture
 
-pgai consists of [SQL](./projects/extension/sql) scripts and a [Python](./projects/extension/ai) package.
+pgai consists of [SQL](/projects/extension/sql) scripts and a [Python](/projects/extension/ai) package.
 
 * [Develop SQL in pgai](#develop-sql-in-pgai)
 * [Develop Python in pgai](#develop-python-in-pgai)
@@ -166,18 +166,18 @@ pgai consists of [SQL](./projects/extension/sql) scripts and a [Python](./projec
 
 ### Develop SQL in the pgai extension
 
-SQL code used by pgai is maintained in [./projects/extension/sql](./projects/extension/sql).
+SQL code used by pgai is maintained in [./projects/extension/sql](/projects/extension/sql).
 
 The SQL is organized into:
 
-* **Idempotent scripts**: maintained in [./projects/extension/sql/idempotent](./projects/extension/sql/idempotent).
+* **Idempotent scripts**: maintained in [./projects/extension/sql/idempotent](/projects/extension/sql/idempotent).
 
   Idempotent scripts consist of `CREATE OR REPLACE` style statements, usually as
   functions. They are executed in alphanumeric order every time you install or
   upgrade pgai. In general, it is safe to rename these scripts from one version to
   the next.
 
-* **Incremental scripts**: maintained in [./projects/extension/sql/incremental](./projects/extension/sql/incremental).
+* **Incremental scripts**: maintained in [./projects/extension/sql/incremental](/projects/extension/sql/incremental).
 
   Incremental files create tables and other stateful-structures that should not be
   dropped when you upgrade from one version to another. Each incremental script
@@ -187,8 +187,8 @@ The SQL is organized into:
 
   Incremental scripts are executed in alphanumeric order on file name. Once an incremental script is published
   in a release, you must not rename it. To facilitate migration, each incremental file is
-  [wrapped](./projects/extension/sql/migration.sql). Each migration id is tracked in the `migration` table. For more information,
-  see [./projects/extension/sql/head.sql](./projects/extension/sql/head.sql).
+  [wrapped](/projects/extension/sql/migration.sql). Each migration id is tracked in the `migration` table. For more information,
+  see [./projects/extension/sql/head.sql](/projects/extension/sql/head.sql).
 
 * **Built scripts**: `./projects/extension/sql/output/ai--*.sql`
 
@@ -209,7 +209,7 @@ recipes in favor of the SQL-specific just recipes:
 
 1. **Clean your environment**: run `just ext clean-sql` to delete `./projects/extension/sql/output/ai--*<current-version>.sql`.
 
-   The `<current-version>` is defined in `versions()` in [./projects/extension/build.py](./projects/extension/build.py).
+   The `<current-version>` is defined in `versions()` in [./projects/extension/build.py](/projects/extension/build.py).
 
 1. **Build pgai**: run `just ext build` to compile idempotent and incremental scripts
    into `./projects/extension/sql/output/ai--*<current-version>.sql`.
@@ -218,12 +218,12 @@ recipes in favor of the SQL-specific just recipes:
 
 ### Develop Python in the pgai extension
 
-Python code used by the pgai extension is maintained in [./projects/extension/ai](./projects/extension/ai).
+Python code used by the pgai extension is maintained in [./projects/extension/ai](/projects/extension/ai).
 
 Database functions
 written in [plpython3u](https://www.postgresql.org/docs/current/plpython.html)
 can import the modules in this package and any dependencies specified in
-[./projects/extension/pyproject.toml](./projects/extension/pyproject.toml).
+[./projects/extension/pyproject.toml](/projects/extension/pyproject.toml).
 Including the following line at the beginning of the database function body will
 allow you to import. The build process replaces this comment line with Python
 code that makes this possible. Note that the leading four spaces are required.
@@ -322,12 +322,12 @@ changes to existing stuff are required for a new feature.
 ## Release the extension
 
 1. Run `just ext clean-sql` in order to remove any prior generated dev sql.
-2. Edit the [build.py](projects/extension/build.py).
+2. Edit the [build.py](/projects/extension/build.py).
    - Set the version to be released as the first element of the array returned by `versions` function. I.e. `"0.7.0",  # released`.
-3. Run `just ext build-release`. This will generate, among other tasks, the final .sql files in `projects/extension/sql/output` and update the version in [__init__.py](projects/extension/ai/__init__.py).
+3. Run `just ext build-release`. This will generate, among other tasks, the final .sql files in `projects/extension/sql/output` and update the version in [__init__.py](/projects/extension/ai/__init__.py).
 4. As those files are git-ignored, you need to add those to the git index by forcing the addition. 
    - Run `git add -f projects/extension/sql/output/ai--*<YOUR_NEW_VERSION_HERE>.sql`.
-5. Craft the release notes for the new version of the extension. Those should be added into [projects/extension/RELEASE_NOTES.md](projects/extension/RELEASE_NOTES.md).
+5. Craft the release notes for the new version of the extension. Those should be added into [projects/extension/RELEASE_NOTES.md](/projects/extension/RELEASE_NOTES.md).
    - As we are not using release-please, those notes are not automatically generated. Instead, we need to manually add those.  
      You can use the output of the following command to craft the release notes:
      ```shell

--- a/projects/extension/RELEASE_NOTES.md
+++ b/projects/extension/RELEASE_NOTES.md
@@ -166,7 +166,7 @@ an index. For more details, check out the [documentation](/docs/vectorizer/overv
   `openai_list_models()` is now `ai.openai_list_models()`
 - The `pg_database_owner` and the database user running `CREATE EXTENSION` now get
   admin privileges over the extension. Other database users and roles need to
-  be granted privileges to use the extension. You do this using [functions](docs/security/privileges.md).
+  be granted privileges to use the extension. You do this using [functions](/docs/security/privileges.md).
 - The parameter names to the openai*, ollama*, anthropic*, and cohere* functions
   were renamed to remove underscore prefixes and conflicts with reserved and
   non-reserved keywords.

--- a/projects/pgai/CHANGELOG.md
+++ b/projects/pgai/CHANGELOG.md
@@ -105,7 +105,7 @@
 
 * make vectorizer worker robust ([#263](https://github.com/timescale/pgai/issues/263)) ([77c0baf](https://github.com/timescale/pgai/commit/77c0baf57438a837f47c179769bc684edeafbfc8))
 
-## [0.2.0](https://github.com/timescale/pgai/compare/pgai-v0.1.0...pgai-v0.2.0) (2024-11-26)
+## [0.2.0](https://github.com/timescale/pgai/compare/v0.1.0...pgai-v0.2.0) (2024-11-26)
 
 
 ### Features

--- a/projects/pgai/DEVELOPMENT.md
+++ b/projects/pgai/DEVELOPMENT.md
@@ -86,7 +86,7 @@ just -l pgai
 
 ### Testing the pgai library
 
-Be sure to add unit tests to the [tests](./projects/pgai/tests) directory when
+Be sure to add unit tests to the [tests](/projects/pgai/tests) directory when
 you add or modify code. Use the following commands to check your work before
 submitting a PR.
 


### PR DESCRIPTION
## Description

This PR fixes all markdown links in our docs. 

I used `lychee --exclude-loopback --accept '403'`, as we run in our GH actions.
Pending to add this into the dev dockerfile, but won't happen in this PR.