### PR TITLE
ci: fix concurrency group to avoid conflicts with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.client_payload.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Since now our CI runs on the base branch, we are having conflicts whenever a build runs in parallel. See the error:

![Screenshot_jZDzdYah](https://github.com/user-attachments/assets/ab0b580f-dfc3-4b45-8777-ba8cc8752266)

With this change, we are generating the group considering the ref of the branch of the PR. 
