### PR TITLE
chore: fix concurrency & add new workflow to rule them all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.client_payload.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -1,0 +1,19 @@
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Fixes concurrency relying on `github.event.pull_request.head.ref` given that
the current reference doesn't exist, but couldn't blame the author, github docs aren't great,
retrieved the info for pull_request events from [this](https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#get-a-review-comment-for-a-pull-request) doc.

Then adds a new workflow so we can make it the only mandatory,
it'll make sure that all the triggered workflows have passed. 
This way we can avoid having to bypass checks merging docs,
which are no longer triggering code builds.