### PR TITLE
chore: make token count log less verbose

### DIFF
--- a/projects/pgai/pgai/vectorizer/embedders/openai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/openai.py
@@ -219,8 +219,8 @@ class OpenAI(ApiKeyMixin, BaseURLMixin, BaseModel, Embedder):
 
             tokenized = encoder.encode_ordinary(document)
             total_tokens += len(tokenized)
-            await logger.adebug(f"Total tokens in batch: {total_tokens}")
             encoded_documents.append(tokenized)
+        await logger.adebug(f"Total tokens in batch: {total_tokens}")
         return encoded_documents
 
     @cached_property


### PR DESCRIPTION
The 'Total tokens in batch' log was printed for each document in a batch, now it only prints once, once all documents are processed.