### PR TITLE
fix: avoid timeouts on merge-gatewkeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -16,4 +16,5 @@ jobs:
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 900 # Bumping from 10m by default to 15m.
 


### PR DESCRIPTION
we've seen failures on CI due to the default timeout. bumping it to avoid them.
example [run](https://github.com/timescale/pgai/actions/runs/13660426915/job/38190070031) where everything was green but lasted more than 10m.