### PR TITLE
feat: add download-models command

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import click
+import docling.utils.model_downloader
 import psycopg
 import structlog
 from ddtrace import tracer
@@ -21,6 +22,7 @@ from pytimeparse import parse  # type: ignore
 from .__init__ import __version__
 from .vectorizer.embeddings import ApiKeyMixin
 from .vectorizer.features import Features
+from .vectorizer.parsing import DOCLING_CACHE_DIR
 from .vectorizer.vectorizer import Vectorizer, Worker
 
 load_dotenv()
@@ -192,6 +194,14 @@ def shutdown_handler(signum: int, _frame: Any):
     signame = signal.Signals(signum).name
     log.info(f"received {signame}, exiting")
     exit(0)
+
+
+@click.command(name="download-models")
+def download_models():
+    docling.utils.model_downloader.download_models(
+        progress=True,
+        output_dir=DOCLING_CACHE_DIR,  # pyright: ignore [reportUndefinedVariable]
+    )
 
 
 @click.command(name="worker")
@@ -367,4 +377,5 @@ def cli():
 
 
 vectorizer.add_command(vectorizer_worker)
+vectorizer.add_command(download_models)
 cli.add_command(vectorizer)

--- a/projects/pgai/pgai/vectorizer/parsing.py
+++ b/projects/pgai/pgai/vectorizer/parsing.py
@@ -99,11 +99,14 @@ class ParsingPyMuPDF(BaseDocumentParsing):
             return pymupdf4llm.to_markdown(pdf_document)  # type: ignore
 
 
+DOCLING_CACHE_DIR = Path.home().joinpath(".cache/docling/models")
+
+
 class ParsingDocling(BaseDocumentParsing):
     """Document parsing implementation using Docling."""
 
     implementation: Literal["docling"]  # type: ignore[reportIncompatibleVariableOverride]
-    cache_dir: Path | str = Path.home().joinpath(".cache/docling/models")
+    cache_dir: Path | str = DOCLING_CACHE_DIR
 
     @override
     def parse_doc(self, row: dict[str, Any], payload: LoadedDocument) -> str:  # noqa: ARG002

--- a/projects/pgai/tests/test_model_download.py
+++ b/projects/pgai/tests/test_model_download.py
@@ -1,0 +1,63 @@
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+def test_download_models():
+    """Test that download-models command works correctly."""
+    # Create a temporary directory for the test
+    with patch("docling.utils.model_downloader.download_models") as mock_download:
+        from pgai.cli import download_models
+        from pgai.vectorizer.parsing import DOCLING_CACHE_DIR
+
+        # Run the CLI command
+        result = CliRunner().invoke(download_models)
+
+        # Check that the command executed successfully
+        assert result.exit_code == 0
+
+        # Verify that download_models was called with the correct parameters
+        mock_download.assert_called_once_with(
+            progress=True,
+            output_dir=DOCLING_CACHE_DIR,
+        )
+
+
+@pytest.mark.skip("Integration test")
+def test_download_models_integration():
+    """Integration test for the download-models command.
+
+    This test actually downloads the models (to a temporary directory)
+    and verifies that files were created.
+    """
+
+    # Create a temporary directory for the test
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Mock the DOCLING_CACHE_DIR to use our temporary directory
+        with patch("pgai.vectorizer.parsing.DOCLING_CACHE_DIR", temp_path):
+            from pgai.cli import download_models
+
+            # Ensure directory is empty
+            if temp_path.exists():
+                for item in temp_path.iterdir():
+                    if item.is_file():
+                        item.unlink()
+                    elif item.is_dir():
+                        shutil.rmtree(item)
+
+            # Run the CLI command
+            result = CliRunner().invoke(download_models)
+
+            # Check that the command executed successfully
+            assert result.exit_code == 0
+
+            # Verify that files were downloaded (directory should no longer be empty)
+            assert any(
+                temp_path.iterdir()
+            ), "No files were downloaded to the models directory"

--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -17,6 +17,7 @@ from mitmproxy.tools.dump import DumpMaster
 from testcontainers.core.image import DockerImage  # type:ignore
 from testcontainers.postgres import PostgresContainer  # type:ignore
 
+from pgai.vectorizer.parsing import DOCLING_CACHE_DIR
 from pgai.vectorizer.vectorizer import TIKTOKEN_CACHE_DIR
 
 DIMENSION_COUNT = 1536
@@ -30,7 +31,7 @@ def download_docling_models():
     # Models are downloaded to: ~/.cache/huggingface/hub/models--ds4sd--docling-models
     docling.utils.model_downloader.download_models(
         progress=True,
-        output_dir=Path.home().joinpath(".cache/docling/models"),
+        output_dir=DOCLING_CACHE_DIR,
     )
 
 


### PR DESCRIPTION
Adding a `pgai vectorizer download-models` command that allows eagerly triggering a docling model download. This allows us to download the models while building our cloud image, instead of the lambda downloading the files new on each invocation.