### PR TITLE
move ext venv in docker image and add missing dependency

### DIFF
--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -63,12 +63,11 @@ FROM base
 ENV WHERE_AM_I=docker
 USER root
 
-RUN pip install --break-system-packages uv==0.5.20
+RUN pip install --break-system-packages uv==0.6.3
 
 WORKDIR /pgai
 
-## install our test python dependencies
-COPY pyproject.toml uv.lock requirements-lock.txt build.py /pgai
-COPY ai /pgai/ai
-RUN uv sync
-ENV PATH="/pgai/.venv/bin:$PATH"
+# install only our python dependencies for dev/test
+COPY pyproject.toml uv.lock /py/
+RUN uv sync --directory /py --no-install-project --only-dev --frozen
+ENV PATH="/py/.venv/bin:$PATH"

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -451,7 +451,6 @@ class Actions:
                 "docker run -d --name pgai-ext --hostname pgai-ext -e POSTGRES_HOST_AUTH_METHOD=trust",
                 networking,
                 f"--mount type=bind,src={ext_dir()},dst=/pgai",
-                "--mount type=volume,dst=/pgai/.venv",
                 "-e OPENAI_API_KEY",
                 "-e COHERE_API_KEY",
                 "-e MISTRAL_API_KEY",

--- a/projects/extension/pyproject.toml
+++ b/projects/extension/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "psycopg[binary]==3.2.1",
     "uv==0.5.20",
     "pgspot>=0.9.0",
+    "requests==2.32.3",
 ]
 
 [tool.setuptools.dynamic]

--- a/projects/extension/uv.lock
+++ b/projects/extension/uv.lock
@@ -1547,6 +1547,7 @@ dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "python-dotenv" },
+    { name = "requests" },
     { name = "ruff" },
     { name = "uv" },
 ]
@@ -1574,6 +1575,7 @@ dev = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.1" },
     { name = "pytest", specifier = "==8.3.2" },
     { name = "python-dotenv", specifier = "==1.0.1" },
+    { name = "requests", specifier = "==2.32.3" },
     { name = "ruff", specifier = "==0.6.9" },
     { name = "uv", specifier = "==0.5.20" },
 ]


### PR DESCRIPTION
- The venv in the extension's docker container only needs the dev dependencies in it.
- Moves the venv in the docker container to a path that is not mounted, so that the venv in the container cannot clash with the one on the host
- the requests library was missing from the dev dependencies in pyproject.toml