### PR TITLE
build(extension): mount entire repo in ext dev container

### DIFF
--- a/projects/extension/DEVELOPMENT.md
+++ b/projects/extension/DEVELOPMENT.md
@@ -41,7 +41,8 @@ To make changes to pgai:
    ```bash
    just ext docker-run
    ```
-   The `projects/extension` directory is mounted to `/pgai` in the running container.
+   The root of the repo directory is mounted to `/pgai` in the running container.
+   The working directory is at `/pgai/projects/extension`.
 
 1. Work inside the container:
    * **Docker shell**:
@@ -121,7 +122,7 @@ To set up the tests:
     ENABLE_SECRETS_TESTS=1
     ```
 
-2. Some tests require extra environment variables to be added to the .env file
+1. Some tests require extra environment variables to be added to the .env file
    - **OpenAI**:
       - `OPENAI_API_KEY` - an [OpenAI API Key](https://platform.openai.com/api-keys) for OpenAI unit testing.
    - **Ollama**:
@@ -135,12 +136,43 @@ To set up the tests:
 
    Providing these keys automatically enables the corresponding tests.
 
+## Set up your environment
+The pgai extension uses `uv` for dependency management. Dependencies are listed
+in the [pyproject.toml](/projects/extension/pyproject.toml) file. uv is already installed in the development
+docker container. To use it in your local environment, follow uv's
+[installation instructions](https://github.com/astral-sh/uv#installation).
+Make sure your uv version is at least `0.5.x`.
+```bash
+uv --version
+```
+
+If not, upgrade it with this command.
+
+```bash
+uv self update
+```
+
+Change directory into the [projects/extension](/projects/extension) directory and create a
+virtual environment. Then, activate it.
+
+```bash
+cd projects/extension
+uv venv
+source .venv/bin/activate
+```
+
+Install the project's dependencies into the virtual environment.
+
+```bash
+uv sync --no-install-project
+```
+
+_NOTE:_ Inside the development container, the python dev/test dependencies are installed
+into a virtual environment at `/py/.venv/`.
+
 ## Dependency management in the pgai extension
 
-The pgai extension uses `uv` for dependency management. Dependencies are listed
-in the [pyproject.toml](/projects/extension/pyproject.toml) file.
-uv is already installed in the development docker container. To use it in your
-local environment, follow uv's [installation instructions](https://github.com/astral-sh/uv#installation).
+Dependencies are listed in the [pyproject.toml](/projects/extension/pyproject.toml) file.
 
 1. The basic commands are:
    1. **Install dependencies**: `uv sync`

--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -65,9 +65,9 @@ USER root
 
 RUN pip install --break-system-packages uv==0.6.3
 
-WORKDIR /pgai
-
 # install only our python dependencies for dev/test
 COPY pyproject.toml uv.lock /py/
 RUN uv sync --directory /py --no-install-project --only-dev --frozen
 ENV PATH="/py/.venv/bin:$PATH"
+
+WORKDIR /pgai/projects/extension

--- a/projects/extension/build.py
+++ b/projects/extension/build.py
@@ -326,7 +326,7 @@ class Actions:
     def test_server() -> None:
         """runs the test http server in the docker container"""
         if where_am_i() == "host":
-            cmd = "docker exec -it -w /pgai/tests/vectorizer pgai-ext fastapi dev server.py"
+            cmd = "docker exec -it -w /pgai/projects/extension/tests/vectorizer pgai-ext fastapi dev server.py"
             subprocess.run(cmd, shell=True, check=True, env=os.environ, cwd=ext_dir())
         else:
             cmd = "uv run --no-project fastapi dev server.py"
@@ -450,7 +450,8 @@ class Actions:
             [
                 "docker run -d --name pgai-ext --hostname pgai-ext -e POSTGRES_HOST_AUTH_METHOD=trust",
                 networking,
-                f"--mount type=bind,src={ext_dir()},dst=/pgai",
+                f"--mount type=bind,src={ext_dir().parent.parent},dst=/pgai",
+                "-w /pgai/projects/extension",
                 "-e OPENAI_API_KEY",
                 "-e COHERE_API_KEY",
                 "-e MISTRAL_API_KEY",

--- a/projects/extension/tests/contents/test_contents.py
+++ b/projects/extension/tests/contents/test_contents.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import psycopg
 import pytest
@@ -22,7 +22,9 @@ def where_am_i() -> str:
 
 
 def docker_dir() -> str:
-    return "/pgai/tests/contents"
+    return str(
+        PosixPath("/").joinpath("pgai", "projects", "extension", "tests", "contents")
+    )
 
 
 def host_dir() -> Path:

--- a/projects/extension/tests/dump_restore/test_dump_restore.py
+++ b/projects/extension/tests/dump_restore/test_dump_restore.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import psycopg
 import pytest
@@ -25,7 +25,11 @@ def where_am_i() -> str:
 
 
 def docker_dir() -> str:
-    return "/pgai/tests/dump_restore"
+    return str(
+        PosixPath("/").joinpath(
+            "pgai", "projects", "extension", "tests", "dump_restore"
+        )
+    )
 
 
 def host_dir() -> Path:

--- a/projects/extension/tests/privileges/test_privileges.py
+++ b/projects/extension/tests/privileges/test_privileges.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import psycopg
 import pytest
@@ -22,7 +22,9 @@ def where_am_i() -> str:
 
 
 def docker_dir() -> str:
-    return "/pgai/tests/privileges"
+    return str(
+        PosixPath("/").joinpath("pgai", "projects", "extension", "tests", "privileges")
+    )
 
 
 def host_dir() -> Path:

--- a/projects/extension/tests/upgrade/test_upgrade.py
+++ b/projects/extension/tests/upgrade/test_upgrade.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from collections import namedtuple
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import psycopg
 import pytest
@@ -32,7 +32,9 @@ def where_am_i() -> str:
 
 
 def docker_dir() -> str:
-    return "/pgai/tests/upgrade"
+    return str(
+        PosixPath("/").joinpath("pgai", "projects", "extension", "tests", "upgrade")
+    )
 
 
 def host_dir() -> Path:

--- a/projects/pgai/tests/vectorizer/conftest.py
+++ b/projects/pgai/tests/vectorizer/conftest.py
@@ -65,8 +65,8 @@ def vcr_():
 def postgres_container_manager() -> (
     Generator[Callable[[bool], PostgresContainer], None, None]
 ):
-    extension_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "../../../extension/")
+    extension_dir = (
+        Path(__file__).parent.parent.parent.parent.joinpath("extension").resolve()
     )
     image = DockerImage(path=extension_dir, tag="pgai-test-db").build(  # type: ignore
         target="pgai-test-db"


### PR DESCRIPTION
mounts the entire repo from the host into the extension dev container. this makes it easier to test examples, access git info, etc.