### PR TITLE
docs: fix typo in vectorizer overview file

### DIFF
--- a/docs/vectorizer/overview.md
+++ b/docs/vectorizer/overview.md
@@ -115,7 +115,7 @@ SELECT ai.create_vectorizer(
 );
 ```
 
-This example uses the `ollama-embed-text` embedding model hosted on a local
+This example uses the `nomic-embed-text` embedding model hosted on a local
 Ollama instance. Vectorizer supports other embedding providers, for more details
 consult the [embedding configuration](/docs/vectorizer/api-reference.md#embedding-configuration)
 section of the vectorizer API reference.


### PR DESCRIPTION
This PR fixes a minor documentation error where the example mistakenly referred to the embedding model as `ollama-embed-text` instead of `nomic-embed-text`. The corrected example now uses `nomic-embed-text`, which aligns with the rest of the vectorizer documentation.