### PR TITLE
fix: move UUID PK serialization into pgai lib

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import json
 import logging
 import os
 import random
@@ -9,9 +8,7 @@ import sys
 import time
 import traceback
 from collections.abc import Sequence
-from functools import partial
 from typing import Any
-from uuid import UUID
 
 import click
 import psycopg
@@ -19,9 +16,7 @@ import structlog
 from ddtrace import tracer
 from dotenv import load_dotenv
 from psycopg.rows import dict_row, namedtuple_row
-from psycopg.types.json import set_json_dumps
 from pytimeparse import parse  # type: ignore
-from typing_extensions import override
 
 from .__init__ import __version__
 from .vectorizer.embeddings import ApiKeyMixin
@@ -181,16 +176,6 @@ class TimeDurationParamType(click.ParamType):
             )
 
 
-class UUIDEncoder(json.JSONEncoder):
-    """A JSON encoder which can dump UUID."""
-
-    @override
-    def default(self, o: Any):
-        if isinstance(o, UUID):
-            return str(o)
-        return json.JSONEncoder.default(self, o)
-
-
 def get_log_level(level: str) -> int:
     level_upper = level.upper()
     # We are targeting python 3.10 that's why we need to use getLevelName which
@@ -283,8 +268,6 @@ def vectorizer_worker(
 
     dynamic_mode = len(vectorizer_ids) == 0
     valid_vectorizer_ids = []
-
-    set_json_dumps(partial(json.dumps, cls=UUIDEncoder))
 
     can_connect = False
     pgai_version = None

--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -1,11 +1,13 @@
 import asyncio
+import json
 import os
 import threading
 import time
 from collections.abc import Callable
-from functools import cached_property
+from functools import cached_property, partial
 from itertools import repeat
 from typing import Any, TypeAlias
+from uuid import UUID
 
 import numpy as np
 import psycopg
@@ -14,9 +16,10 @@ from ddtrace import tracer
 from pgvector.psycopg import register_vector_async  # type: ignore
 from psycopg import AsyncConnection, sql
 from psycopg.rows import dict_row
-from psycopg.types.json import Jsonb
+from psycopg.types.json import Jsonb, set_json_dumps
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Field
+from typing_extensions import override
 
 from .chunking import (
     LangChainCharacterTextSplitter,
@@ -430,6 +433,16 @@ class ProcessingStats:
         )
 
 
+class UUIDEncoder(json.JSONEncoder):
+    """A JSON encoder which can dump UUID."""
+
+    @override
+    def default(self, o: Any):
+        if isinstance(o, UUID):
+            return str(o)
+        return json.JSONEncoder.default(self, o)
+
+
 class Worker:
     """
     Responsible for processing items from the work queue and generating embeddings.
@@ -479,6 +492,7 @@ class Worker:
             self.db_url, autocommit=True
         ) as conn:
             try:
+                set_json_dumps(partial(json.dumps, cls=UUIDEncoder), context=conn)
                 await register_vector_async(conn)
                 await self.vectorizer.config.embedding.setup()
                 while True:


### PR DESCRIPTION
In b242d7049a1c38785c510f0a5a36af31537cb610 we introduced a fix for broken UUID serialization. Unfortunately this fix doesn't apply to consumers of pgai as a library.

This change moves the fix from the cli to the upper-most level in the worker.