### PR TITLE
fix(vectorizer): always use column ordering from table rather than primary key ordering

### DIFF
--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -3,9 +3,8 @@ import json
 import os
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import cached_property, partial
-from itertools import repeat
 from typing import Any, TypeAlias
 from uuid import UUID
 
@@ -61,6 +60,8 @@ class PkAtt:
     """
 
     attname: str
+    pknum: int
+    attnum: int
 
 
 @dataclass
@@ -139,10 +140,14 @@ class VectorizerQueryBuilder:
         """Generates the SQL expression for a comma separated list of the
         attributes of a primary key. For example, if the primary key has 2
         fields (author, title), it will return a sql.Composed object that
-        represents the SQL expression "author, title".
+        represents the SQL expression "author, title". The columns will be
+        listed in the order they appear in the table NOT the primary key.
         """
         return sql.SQL(" ,").join(
-            [sql.Identifier(a.attname) for a in self.vectorizer.source_pk]
+            [
+                sql.Identifier(a.attname)
+                for a in sorted(self.vectorizer.source_pk, key=lambda pk: pk.attnum)
+            ]
         )
 
     @cached_property
@@ -150,15 +155,25 @@ class VectorizerQueryBuilder:
         """
         Returns a list of primary key attribute names. For example, if the
         primary key has 2 fields (author, title), it will return ["author", "title"].
+        The columns will be listed in the order they appear in the table NOT the
+        primary key.
         """
-        return [a.attname for a in self.vectorizer.source_pk]
+        return [
+            a.attname
+            for a in sorted(self.vectorizer.source_pk, key=lambda pk: pk.attnum)
+        ]
 
     @property
     def pk_fields(self) -> list[sql.Identifier]:
         """
         Returns the SQL identifiers for primary key fields.
+        The columns will be listed in the order they appear in the table NOT the
+        primary key.
         """
-        return [sql.Identifier(a.attname) for a in self.vectorizer.source_pk]
+        return [
+            sql.Identifier(a.attname)
+            for a in sorted(self.vectorizer.source_pk, key=lambda pk: pk.attnum)
+        ]
 
     @property
     def target_table_ident(self) -> sql.Identifier:
@@ -306,16 +321,6 @@ class VectorizerQueryBuilder:
         ).format(
             self.target_table_ident,
             self.pk_fields_sql,
-        )
-
-    @cached_property
-    def insert_embeddings_query(self) -> sql.Composed:
-        return sql.SQL(
-            "INSERT INTO {} ({}, chunk_seq, chunk, embedding) VALUES ({}, %s, %s, %s)"
-        ).format(
-            self.target_table_ident,
-            self.pk_fields_sql,
-            sql.SQL(" ,").join(list(repeat(sql.SQL("%s"), len(self.pk_fields)))),
         )
 
     @cached_property
@@ -477,7 +482,7 @@ class Worker:
             lambda _loops, _res: True
         )
         self.features = features
-        self.copy_types: None | list[int] = None
+        self.copy_types: None | Sequence[int] = None
         self.worker_tracking = worker_tracking
 
     async def run(self) -> int:
@@ -703,6 +708,36 @@ class Worker:
         async with conn.cursor() as cursor:
             await cursor.execute(self.queries.delete_embeddings_query(len(items)), ids)
 
+    async def _load_copy_types(self, conn: AsyncConnection) -> None:
+        """
+        Loads the database types for the columns of the target table into
+        self.copy_types.
+
+        Args:
+            conn (AsyncConnection): The database connection.
+        """
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                select a.atttypid
+                from pg_catalog.pg_class k
+                inner join pg_catalog.pg_namespace n
+                    on (k.relnamespace operator(pg_catalog.=) n.oid)
+                inner join pg_catalog.pg_attribute a
+                    on (k.oid operator(pg_catalog.=) a.attrelid)
+                where n.nspname operator(pg_catalog.=) %s
+                and k.relname operator(pg_catalog.=) %s
+                and a.attname operator(pg_catalog.!=) 'embedding_uuid'
+                and a.attnum operator(pg_catalog.>) 0
+                order by a.attnum
+            """,
+                (self.vectorizer.target_schema, self.vectorizer.target_table),
+            )
+            self.copy_types = [row[0] for row in await cursor.fetchall()]
+        assert self.copy_types is not None
+        # len(source_pk) + chunk_seq + chunk + embedding
+        assert len(self.copy_types) == len(self.vectorizer.source_pk) + 3
+
     @tracer.wrap()
     async def _copy_embeddings(
         self,
@@ -717,29 +752,16 @@ class Worker:
             conn (AsyncConnection): The database connection.
             records (list[EmbeddingRecord]): The embedding records to be copied.
         """
-        async with conn.cursor(binary=True) as cursor:
-            if self.copy_types is None:
-                await cursor.execute(
-                    """
-                    select a.atttypid
-                    from pg_catalog.pg_class k
-                    inner join pg_catalog.pg_namespace n
-                        on (k.relnamespace operator(pg_catalog.=) n.oid)
-                    inner join pg_catalog.pg_attribute a
-                        on (k.oid operator(pg_catalog.=) a.attrelid)
-                    where n.nspname operator(pg_catalog.=) %s
-                    and k.relname operator(pg_catalog.=) %s
-                    and a.attname operator(pg_catalog.!=) 'embedding_uuid'
-                    and a.attnum operator(pg_catalog.>) 0
-                    order by a.attnum
-                """,
-                    (self.vectorizer.target_schema, self.vectorizer.target_table),
-                )
-                self.copy_types = [row[0] for row in await cursor.fetchall()]
-            async with cursor.copy(self.queries.copy_embeddings_query) as copy:
-                copy.set_types(self.copy_types)
-                for record in records:
-                    await copy.write_row(record)
+        if self.copy_types is None:
+            await self._load_copy_types(conn)
+        async with (
+            conn.cursor(binary=True) as cursor,
+            cursor.copy(self.queries.copy_embeddings_query) as copy,
+        ):
+            assert self.copy_types is not None  # ugh. make pyright happy
+            copy.set_types(self.copy_types)
+            for record in records:
+                await copy.write_row(record)
 
     async def _insert_vectorizer_errors(
         self,

--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -74,6 +74,8 @@ markers = [
     "postgres_params: Parameters for the postgres_container fixture (e.g. `load_openai_key=False`)"
 ]
 python_files = ["test_*.py"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.pyright]
 # this enables practically every flag given by pyright.
@@ -117,6 +119,7 @@ allow-direct-references = true
 dev-dependencies = [
     "ruff==0.6.9",
     "pytest==8.3.2",
+    "pytest-asyncio==0.25.3",
     "python-dotenv==1.0.1",
     "vcrpy==7.0.0",
     "pyright==1.1.385",

--- a/projects/pgai/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer.py
@@ -1,18 +1,10 @@
-import os
-
 import psycopg
-import pytest
 from psycopg.rows import namedtuple_row
 from psycopg.sql import SQL, Identifier
 
 from pgai import cli
 from pgai.vectorizer.features import Features
 from pgai.vectorizer.worker_tracking import WorkerTracking
-
-# skip tests in this module if disabled
-enable_vectorizer_tool_tests = os.getenv("ENABLE_VECTORIZER_TOOL_TESTS")
-if not enable_vectorizer_tool_tests or enable_vectorizer_tool_tests == "0":
-    pytest.skip(allow_module_level=True)
 
 
 def db_url(user: str, dbname: str) -> str:
@@ -169,7 +161,8 @@ async def test_vectorizer_weird_pk():
                 , c timestamp with time zone not null
                 , d tstzrange not null
                 , note text not null
-                , primary key (a, b, c, d)
+                -- use a different ordering for pk to ensure we handle it
+                , primary key (a, c, b, d)
                 )
             """)
         # create a vectorizer for the table

--- a/projects/pgai/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer.py
@@ -1,37 +1,17 @@
 import psycopg
 from psycopg.rows import namedtuple_row
 from psycopg.sql import SQL, Identifier
+from testcontainers.postgres import PostgresContainer  # type: ignore
 
 from pgai import cli
 from pgai.vectorizer.features import Features
 from pgai.vectorizer.worker_tracking import WorkerTracking
 
 
-def db_url(user: str, dbname: str) -> str:
-    return f"postgres://{user}@127.0.0.1:5432/{dbname}"
-
-
-def create_database(dbname: str) -> None:
+async def test_vectorizer_internal(postgres_container: PostgresContainer):
+    db_url = postgres_container.get_connection_url(driver=None)
     with (
-        psycopg.connect(
-            db_url(user="postgres", dbname="postgres"), autocommit=True
-        ) as con,
-        con.cursor() as cur,
-    ):
-        cur.execute(
-            SQL("drop database if exists {dbname} with (force)").format(
-                dbname=Identifier(dbname)
-            )
-        )
-        cur.execute(SQL("create database {dbname}").format(dbname=Identifier(dbname)))
-
-
-async def test_vectorizer_internal():
-    db = "vcli0"
-    create_database(db)
-    _db_url = db_url("postgres", db)
-    with (
-        psycopg.connect(_db_url, autocommit=True, row_factory=namedtuple_row) as con,
+        psycopg.connect(db_url, autocommit=True, row_factory=namedtuple_row) as con,
         con.cursor() as cur,
     ):
         cur.execute("create extension if not exists vectorscale cascade")
@@ -40,8 +20,8 @@ async def test_vectorizer_internal():
         cur.execute("create extension if not exists ai cascade")
         pgai_version = cli.get_pgai_version(cur)
         assert pgai_version is not None
-        assert len(cli.get_vectorizer_ids(_db_url)) == 0
-        assert len(cli.get_vectorizer_ids(_db_url, [42, 19])) == 0
+        assert len(cli.get_vectorizer_ids(db_url)) == 0
+        assert len(cli.get_vectorizer_ids(db_url, [42, 19])) == 0
         cur.execute("create extension if not exists timescaledb")
         cur.execute("drop table if exists note0")
         cur.execute("""
@@ -91,21 +71,21 @@ async def test_vectorizer_internal():
         vectorizer_expected = cur.fetchone()
 
         # test cli.get_vectorizer_ids
-        assert len(cli.get_vectorizer_ids(_db_url)) == 1
-        assert len(cli.get_vectorizer_ids(_db_url, [42, 19])) == 0
-        assert len(cli.get_vectorizer_ids(_db_url, [vectorizer_id, 19])) == 1
-        assert len(cli.get_vectorizer_ids(_db_url, [vectorizer_id])) == 1
+        assert len(cli.get_vectorizer_ids(db_url)) == 1
+        assert len(cli.get_vectorizer_ids(db_url, [42, 19])) == 0
+        assert len(cli.get_vectorizer_ids(db_url, [vectorizer_id, 19])) == 1
+        assert len(cli.get_vectorizer_ids(db_url, [vectorizer_id])) == 1
 
         # test cli.get_vectorizer
-        vectorizer_actual = cli.get_vectorizer(_db_url, vectorizer_id)
+        vectorizer_actual = cli.get_vectorizer(db_url, vectorizer_id)
         assert vectorizer_actual is not None
         assert vectorizer_expected.source_table == vectorizer_actual.source_table  # type: ignore
 
         # run the vectorizer
         features = Features(pgai_version)
-        worker_tracking = WorkerTracking(_db_url, 500, features, "0.0.1")
+        worker_tracking = WorkerTracking(db_url, 500, features, "0.0.1")
         await cli.run_vectorizer(
-            _db_url, vectorizer_actual, 1, features, worker_tracking
+            db_url, vectorizer_actual, 1, features, worker_tracking
         )
 
         # make sure the queue was emptied
@@ -138,14 +118,12 @@ async def test_vectorizer_internal():
         assert actual is True
 
 
-async def test_vectorizer_weird_pk():
+async def test_vectorizer_weird_pk(postgres_container: PostgresContainer):
     # make sure we can handle a multi-column primary key with "interesting" data types
     # this has implications on the COPY with binary format logic in the vectorizer
-    db = "vcli1"
-    create_database(db)
-    _db_url = db_url("postgres", db)
+    db_url = postgres_container.get_connection_url(driver=None)
     with (
-        psycopg.connect(_db_url, autocommit=True, row_factory=namedtuple_row) as con,
+        psycopg.connect(db_url, autocommit=True, row_factory=namedtuple_row) as con,
         con.cursor() as cur,
     ):
         cur.execute("create extension if not exists vectorscale cascade")
@@ -194,7 +172,7 @@ async def test_vectorizer_weird_pk():
         vectorizer_expected = cur.fetchone()
 
         # test cli.get_vectorizer
-        vectorizer_actual = cli.get_vectorizer(_db_url, vectorizer_id)
+        vectorizer_actual = cli.get_vectorizer(db_url, vectorizer_id)
         assert vectorizer_actual is not None
         assert vectorizer_expected.source_table == vectorizer_actual.source_table  # type: ignore
 
@@ -212,9 +190,9 @@ async def test_vectorizer_weird_pk():
 
         # run the vectorizer
         features = Features(pgai_version)
-        worker_tracking = WorkerTracking(_db_url, 500, features, "0.0.1")
+        worker_tracking = WorkerTracking(db_url, 500, features, "0.0.1")
         await cli.run_vectorizer(
-            _db_url, vectorizer_actual, 1, features, worker_tracking
+            db_url, vectorizer_actual, 1, features, worker_tracking
         )
 
         # make sure the queue was emptied

--- a/projects/pgai/uv.lock
+++ b/projects/pgai/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '4' and platform_python_implementation != 'PyPy'",
@@ -2089,6 +2090,7 @@ dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "testcontainers" },
@@ -2119,6 +2121,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0,<5.0" },
     { name = "voyageai", specifier = ">=0.3.1,<0.3.2" },
 ]
+provides-extras = ["sqlalchemy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2128,6 +2131,7 @@ dev = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.1" },
     { name = "pyright", specifier = "==1.1.385" },
     { name = "pytest", specifier = "==8.3.2" },
+    { name = "pytest-asyncio", specifier = "==0.25.3" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "ruff", specifier = "==0.6.9" },
     { name = "testcontainers", specifier = "==4.8.1" },
@@ -2614,6 +2618,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/8c/9862305bdcd6020bc7b45b1b5e7397a6caf1a33d3025b9a003b39075ffb2/pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce", size = 1439314 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/f9/cf155cf32ca7d6fa3601bc4c5dd19086af4b320b706919d48a4c79081cf9/pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5", size = 341802 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
A table can have columns in order `A, B, C, D` and a primary key defined in order `A, D, C, B`. When we select items from the source table, we get the records using table column order (not primary key order). When copying into the target table, we were using primary key ordering to construct the SQL command, but table column order to provide the values. This is a bug.

