### PR TITLE
feat: add vectorizer.run method

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -20,7 +20,7 @@ from pytimeparse import parse  # type: ignore
 from .__init__ import __version__
 from .vectorizer.embeddings import ApiKeyMixin
 from .vectorizer.features import Features
-from .vectorizer.vectorizer import Vectorizer, Worker
+from .vectorizer.vectorizer import Vectorizer
 from .vectorizer.worker_tracking import WorkerTracking
 
 load_dotenv()
@@ -132,36 +132,6 @@ def get_vectorizer(db_url: str, vectorizer_id: int) -> Vectorizer:
         return vectorizer
 
 
-async def run_vectorizer(
-    db_url: str,
-    vectorizer: Vectorizer,
-    concurrency: int,
-    features: Features,
-    worker_tracking: WorkerTracking,
-) -> None:
-    tasks = [
-        asyncio.create_task(Worker(db_url, vectorizer, features, worker_tracking).run())
-        for _ in range(concurrency)
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-    # raise any exceptions, but only after all tasks have completed
-    items: int = 0
-    exceptions: list[BaseException] = []
-    for result in results:
-        if isinstance(result, BaseException):
-            # report all exceptions
-            await worker_tracking.save_vectorizer_error(vectorizer.id, str(result))
-            exceptions.append(result)
-        else:
-            items += result
-
-    if len(exceptions) > 0:
-        raise Exception(exceptions)
-
-    log.info("finished processing vectorizer", items=items, vectorizer_id=vectorizer.id)
-
-
 class TimeDurationParamType(click.ParamType):
     name = "time duration"
 
@@ -222,13 +192,6 @@ def shutdown_handler(signum: int, _frame: Any):
     default=[],
 )
 @click.option(
-    "-c",
-    "--concurrency",
-    type=click.IntRange(1),
-    default=1,
-    show_default=True,
-)
-@click.option(
     "--log-level",
     type=click.Choice(
         ["DEBUG", "INFO", "WARN", "ERROR", "FATAL", "CRITICAL"], case_sensitive=False
@@ -251,6 +214,13 @@ def shutdown_handler(signum: int, _frame: Any):
     help="Exit after processing all available work (implies --exit-on-error).",
 )
 @click.option(
+    "-c",
+    "--concurrency",
+    type=click.IntRange(1),
+    default=None,
+    show_default=True,
+)
+@click.option(
     "--exit-on-error",
     type=click.BOOL,
     default=None,
@@ -260,20 +230,20 @@ def shutdown_handler(signum: int, _frame: Any):
 def vectorizer_worker(
     db_url: str,
     vectorizer_ids: Sequence[int],
-    concurrency: int,
     log_level: str,
     poll_interval: int,
     once: bool,
+    concurrency: int | None,
     exit_on_error: bool | None,
 ) -> None:
     asyncio.run(
         async_run_vectorizer_worker(
             db_url,
             vectorizer_ids,
-            concurrency,
             log_level,
             poll_interval,
             once,
+            concurrency,
             exit_on_error,
         )
     )
@@ -298,10 +268,10 @@ async def handle_error(
 async def async_run_vectorizer_worker(
     db_url: str,
     vectorizer_ids: Sequence[int],
-    concurrency: int,
     log_level: str,
     poll_interval: int,
     once: bool,
+    concurrency: int | None,
     exit_on_error: bool | None,
 ) -> None:
     # gracefully handle being asked to shut down
@@ -384,8 +354,11 @@ async def async_run_vectorizer_worker(
                         break
 
                     log.info("running vectorizer", vectorizer_id=vectorizer_id)
-                    await run_vectorizer(
-                        db_url, vectorizer, concurrency, features, worker_tracking
+                    await vectorizer.run(
+                        db_url=db_url,
+                        features=features,
+                        worker_tracking=worker_tracking,
+                        concurrency=concurrency,
                     )
         except psycopg.OperationalError as e:
             if "connection failed" in str(e):

--- a/projects/pgai/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/tests/vectorizer/test_vectorizer.py
@@ -84,9 +84,8 @@ async def test_vectorizer_internal(postgres_container: PostgresContainer):
         # run the vectorizer
         features = Features.for_testing_latest_version()
         worker_tracking = WorkerTracking(db_url, 500, features, "0.0.1")
-        await cli.run_vectorizer(
-            db_url, vectorizer_actual, 1, features, worker_tracking
-        )
+
+        await vectorizer_actual.run(db_url, features, worker_tracking, 1)
 
         # make sure the queue was emptied
         cur.execute("select ai.vectorizer_queue_pending(%s)", (vectorizer_id,))
@@ -191,9 +190,7 @@ async def test_vectorizer_weird_pk(postgres_container: PostgresContainer):
         # run the vectorizer
         features = Features.for_testing_latest_version()
         worker_tracking = WorkerTracking(db_url, 500, features, "0.0.1")
-        await cli.run_vectorizer(
-            db_url, vectorizer_actual, 1, features, worker_tracking
-        )
+        await vectorizer_actual.run(db_url, features, worker_tracking, 1)
 
         # make sure the queue was emptied
         cur.execute("select ai.vectorizer_queue_pending(%s)", (vectorizer_id,))


### PR DESCRIPTION
This PR moves the `cli.run_worker` function to a `.run` method in the Vectorizer class. 
This new method can be called from any port, such as CLI or a Lambda, so this becomes the main entry point for processing a vectorizer.

For example this is the main difference in the changes on the methods API: 


Previous call:
```python
await cli.run_vectorizer(
    db_url, vectorizer_actual, 1, features, worker_tracking
)
```

New call:
```python
await vectorizer_actual.run(db_url, features, worker_tracking, 1)
```
