### PR TITLE
fix: exclude future links from being analyzed

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -14,6 +14,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude-loopback --accept '403' .
+          args: --exclude-loopback --accept '403' --exclude "https://github.com/timescale/pgai/compare/pgai-v.*" --verbose --no-progress ..
           format: markdown
           jobSummary: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     paths-ignore:
       - "**.md"
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
Our markdown links checker is failing on releases, due to release-please generating yet non existing links. Exclude those types of links from being analyzed.
Also stop running CI for mere changes in workflows.

Workflow failing on release, due to future, non existing links:
https://github.com/timescale/pgai/actions/runs/13950810027

And passing after testing the fix:
https://github.com/timescale/pgai/actions/runs/13950938884/job/39049990520

