### PR TITLE
feat: add timescaledb-toolkit to ext dockerfile

### DIFF
--- a/projects/extension/Dockerfile
+++ b/projects/extension/Dockerfile
@@ -30,7 +30,7 @@ RUN set -e; \
     echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(lsb_release -c -s) main" | tee /etc/apt/sources.list.d/timescaledb.list; \
     wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg; \
     apt-get update -y; \
-    apt-get install -y timescaledb-2-postgresql-${PG_MAJOR}
+    apt-get install -y timescaledb-2-postgresql-${PG_MAJOR} timescaledb-toolkit-postgresql-${PG_MAJOR}
 
 # install pgvectorscale
 RUN set -e; \


### PR DESCRIPTION
PR adds the timescaledb-toolkit to the docker image built for the extension. This allows using the dev image to work with the datasets that are documented in the [tutorials](https://docs.timescale.com/tutorials/latest/) in the docs which relies on functions from the toolkit.