### PR TITLE
test: check that the sql in the library matches the source

### DIFF
--- a/projects/pgai/db/build.py
+++ b/projects/pgai/db/build.py
@@ -88,7 +88,7 @@ class Actions:
         frozen_file().write_text("\n".join(lines))
 
     @staticmethod
-    def build() -> None:
+    def build(check: str | None = None) -> None:
         """constructs the sql files for the extension"""
         check_incremental_sql_files(incremental_sql_files())
         check_idempotent_sql_files(idempotent_sql_files())
@@ -121,7 +121,13 @@ class Actions:
                 wf.write("\n\n")
             wf.flush()
             wf.close()
-        shutil.copyfile(osf, lib_sql_file())
+        if check:
+            expected = output_sql_file().read_text()
+            actual = lib_sql_file().read_text()
+            if expected != actual:
+                fatal("built sql file does not match sql file in library")
+        else:
+            shutil.copyfile(osf, lib_sql_file())
 
     @staticmethod
     def clean() -> None:

--- a/projects/pgai/db/justfile
+++ b/projects/pgai/db/justfile
@@ -22,6 +22,8 @@ clean:
 build:
 	@PG_BIN={{PG_BIN}} ./build.py build
 
+build-check:
+	@PG_BIN={{PG_BIN}} ./build.py build check
 
 test-server:
 	@./build.py test-server

--- a/projects/pgai/justfile
+++ b/projects/pgai/justfile
@@ -54,6 +54,10 @@ lint-fix:
 type-check:
 	@uv run --no-project pyright ./
 
+# Check the built sql script
+db-check:
+    @just db/build-check
+
 # Runs ruff to check formatting of the python source files
 format:
 	@uv run --no-project ruff format --diff ./
@@ -66,7 +70,7 @@ format-fix:
 fix: lint-fix format-fix
 
 # CI pipeline. Runs all recipes needed for ensuring the code is ready to be integrated. Triggered by GH Actions
-ci: install lint type-check format test build
+ci: db-check install lint type-check format test build
 
 # Build Docker image with version tag
 docker-build:


### PR DESCRIPTION
In the extension, we didn't check in built SQL until it was being released; we built the SQL in CI and tested the output. Thus, there was no way for the source to mismatch what was being tested.

This is not the case in the pgai library. You can change the source and forget to build and check in the output.

This PR adds a check to ensure that the built source matches what is checked in to the library.