### PR TITLE
docs: breakout python integrations

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -14,6 +14,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude-loopback --accept '403' --exclude "http://0.0.0.0:8000/*" --exclude "https://github.com/timescale/pgai/compare/pgai-v.*" --verbose --no-progress ..
+          args: --exclude-loopback --accept '403' --exclude "http://0.0.0.0:8000/*" --exclude "https://github.com/timescale/pgai/compare/pgai-v.*" --exclude "https://github.com/timescale/pgai/commit/*"  --verbose --no-progress ..
           format: markdown
           jobSummary: true

--- a/docs/vectorizer/alembic-integration.md
+++ b/docs/vectorizer/alembic-integration.md
@@ -1,0 +1,76 @@
+# Alembic integration
+
+Alembic is a database migration tool that allows you to manage your database schema. This document describes how to use Alembic to manage your vectorizer definitions, since those should be considered part of your database schema. 
+
+We first cover how to create vectorizers using the Alembic operations. Then, we cover how to exclude the tables created and managed by pgai Vectorizer from the autogenerate process.
+
+## Creating vectorizers
+pgai provides native Alembic operations for managing vectorizers. For them to work you need to run `register_operations` in your env.py file. Which registers the pgai operations under the global op context:
+
+```python
+from pgai.alembic import register_operations
+
+register_operations()
+```
+
+Then you can use the `create_vectorizer` operation to create a vectorizer for your model. As well as the `drop_vectorizer` operation to remove it.
+
+```python
+from alembic import op
+from pgai.vectorizer.configuration import (
+    EmbeddingOpenaiConfig,
+    ChunkingCharacterTextSplitterConfig,
+    FormattingPythonTemplateConfig,
+    LoadingColumnConfig,
+    DestinationTableConfig
+)
+
+
+def upgrade() -> None:
+    op.create_vectorizer(
+        source="blog",
+        name="blog_content_embedder",  # Optional custom name for easier reference
+        destination=DestinationTableConfig(
+            destination='blog_embeddings'
+        )
+        loading=LoadingColumnConfig(column_name='content'),
+        embedding=EmbeddingOpenaiConfig(
+            model='text-embedding-3-small',
+            dimensions=768
+        ),
+        chunking=ChunkingCharacterTextSplitterConfig(
+            chunk_size=800,
+            chunk_overlap=400,
+            separator='.',
+            is_separator_regex=False
+        ),
+        formatting=FormattingPythonTemplateConfig(template='$title - $chunk')
+    )
+
+
+def downgrade() -> None:
+    op.drop_vectorizer(name="blog_content_embedder", drop_all=True)
+```
+
+The `create_vectorizer` operation supports all configuration options available in the [SQL API](/docs/vectorizer/api-reference.md).
+
+## Excluding tables created by pgai Vectorizer from Alembic autogeneration
+
+When you create a vectorizer, pgai automatically creates a table to store the vector embeddings. This table is managed by pgai and should not be included in created by alembic migrations. So, if you are using alembic's autogenerate functionality to generate migrations, you will need to exclude these tables from the autogenerate process.
+
+If you are using SQLAlchemy, the `vectorizer_relationship` generates a new SQLAlchemy model, that is available under the attribute that you specify, and those models need to be excluded from the autogenerate process. When those models are created, they are added to a list in your metadata called `pgai_managed_tables` and you can exclude them by adding the following to your `env.py`:
+
+```python
+def include_object(object, name, type_, reflected, compare_to):
+    if type_ == "table" and name in target_metadata.info.get("pgai_managed_tables", set()):
+        return False
+    return True
+
+context.configure(
+      connection=connection,
+      target_metadata=target_metadata,
+      include_object=include_object
+  )
+```
+
+This should now prevent alembic from generating tables for these models when you run `alembic revision --autogenerate`.

--- a/docs/vectorizer/python-integration.md
+++ b/docs/vectorizer/python-integration.md
@@ -1,15 +1,28 @@
-# Creating vectorizers from python
 
-To create a vectorizer from python you use the `CreateVectorizer` helper class from the `pgai.vectorizer` module.
-It accepts all the options listed in the [SQL API](/docs/vectorizer/api-reference.md) and exposes the `to_sql`
-method to generate a SQL query which you can then run through the SQL library of your choice.
+# Overview
 
-First install the pgai library:
+This document describes how to create and run vectorizers from Python.
+
+# Installation
+
+First, install the pgai library:
 ```bash
 pip install pgai
 ```
 
-Then you can create a vectorizer from python:
+Then, you need to install the necessary database tables and functions. All database objects will be created in the `ai` schema. This is done by running the following Python code:
+
+```python
+import pgai
+
+pgai.install(DB_URL)
+```
+
+# Creating vectorizers from python
+
+To help you create vectorizers from python, pgai provides the `CreateVectorizer` helper class. This class makes it easy to generate the `create_vectorizer` SQL statement, by giving you a pythonic interface.
+It accepts all the options listed in the [SQL API](/docs/vectorizer/api-reference.md) and exposes the `to_sql`
+method to generate a SQL query which you can then run through the SQL library of your choice:
 
 ```python
 from pgai.vectorizer import CreateVectorizer
@@ -36,239 +49,21 @@ vectorizer_statement = CreateVectorizer(
 ).to_sql()
 ```
 
-# SQLAlchemy Integration with pgai Vectorizer
-
-The `vectorizer_relationship` is a SQLAlchemy helper that integrates pgai's vectorization capabilities directly into your SQLAlchemy models.
-Think of it as a normal SQLAlchemy [relationship](https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html), but with a preconfigured model instance under the hood.
-This allows you to easily query vector embeddings created by pgai using familiar SQLAlchemy patterns.
-
-## Installation
-
-To use the SQLAlchemy integration, install pgai with the SQLAlchemy extras:
-
-```bash
-pip install "pgai[sqlalchemy]"
-```
-
-## Basic Usage
-
-Here's a basic example of how to use the `vectorizer_relationship`:
+Then, you can run this statement using the PostgreSQL library of your choice. For example, using the [`psycopg`](https://www.psycopg.org/psycopg3/docs/) library:
 
 ```python
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from pgai.sqlalchemy import vectorizer_relationship
+import psycopg
 
-class Base(DeclarativeBase):
-    pass
-
-class BlogPost(Base):
-    __tablename__ = "blog_posts"
-
-    id: Mapped[int] = mapped_column(primary_key=True)
-    title: Mapped[str]
-    content: Mapped[str]
-
-    # Add vector embeddings for the content field
-    content_embeddings = vectorizer_relationship(
-        dimensions=768
-    )
-```
-Note if you work with alembics autogenerate functionality for migrations, also check [Working with alembic](#working-with-alembic).
-
-### Semantic Search
-
-You can then perform semantic similarity search on the field using [pgvector-python's](https://github.com/pgvector/pgvector-python) distance functions:
-
-```python
-from sqlalchemy import func, text
-
-similar_posts = (
-    session.query(BlogPost.content_embeddings)
-    .order_by(
-        BlogPost.content_embeddings.embedding.cosine_distance(
-            func.ai.openai_embed(
-                "text-embedding-3-small",
-                "search query",
-                text("dimensions => 768")
-            )
-        )
-    )
-    .limit(5)
-    .all()
-)
+with psycopg.connect(conn_string) as conn:
+    with conn.cursor() as cursor:
+        cursor.execute(vectorizer_statement)
 ```
 
-Or if you already have the embeddings in your application:
+# Running the vectorizer worker
 
-```python
-similar_posts = (
-    session.query(BlogPost.content_embeddings)
-    .order_by(
-        BlogPost.content_embeddings.embedding.cosine_distance(
-            [3, 1, 2]
-        )
-    )
-    .limit(5)
-    .all()
-)
-```
+You can then run the vectorizer worker using the the CLI tool or the `Worker` class discussed in the [vectorizer worker documentation](/docs/vectorizer/worker.md).
 
-## Configuration
+# Related integrations
 
-The `vectorizer_relationship` accepts the following parameters:
-
-- `dimensions` (int): The size of the embedding vector (required)
-- `target_schema` (str, optional): Override the schema for the embeddings table. If not provided, inherits from the parent model's schema
-- `target_table` (str, optional): Override the table name for embeddings. Default is `{table_name}_embedding_store`
-
-Additional parameters are simply forwarded to the underlying [SQLAlchemy relationship](https://docs.sqlalchemy.org/en/20/orm/relationships.html) so you can configure it as you desire.
-
-Think of the `vectorizer_relationship` as a normal SQLAlchemy relationship, but with a preconfigured model instance under the hood.
-The relationship into the other direction is also automatically set, if you want to change it's configuration you can set the
-`parent_kwargs`parameter. E.g. `parent_kwargs={"lazy": "joined"}` to configure eager loading.
-
-## Setting up the Vectorizer
-
-After defining your model, you need to create the vectorizer using pgai's SQL functions:
-
-```sql
-SELECT ai.create_vectorizer(
-    'blog_posts'::regclass,
-    loading => ai.loading_column('content'),
-    embedding => ai.embedding_openai('text-embedding-3-small', 768),
-    chunking => ai.chunking_recursive_character_text_splitter(
-        50,  -- chunk_size
-        10   -- chunk_overlap
-    )
-);
-```
-
-We recommend adding this to a migration script and run it via alembic.
-
-
-## Querying Embeddings
-
-The `vectorizer_relationship` provides several ways to work with embeddings:
-
-### 1. Direct Access to Embeddings
-
-If you access the class property of your model the `vectorizer_relationship` provide a SQLAlchemy model that you can query directly:
-
-```python
-# Get all embeddings
-embeddings = session.query(BlogPost.content_embeddings).all()
-
-# Access embedding properties
-for embedding in embeddings:
-    print(embedding.embedding)  # The vector embedding
-    print(embedding.chunk)      # The text chunk
-```
-The model will have the primary key fields of the parent model as well as the following fields:
-- `chunk` (str): The text chunk that was embedded
-- `embedding` (Vector): The vector embedding
-- `chunk_seq` (int): The sequence number of the chunk
-- `embedding_uuid` (str): The UUID of the embedding
-- `parent` (ParentModel): The parent model instance
-
-### 2. Relationship Access
-
-
-```python
-blog_post = session.query(BlogPost).first()
-for embedding in blog_post.content_embeddings:
-    print(embedding.chunk)
-```
-Access the original posts through the parent relationship
-```python
-for embedding in similar_posts:
-    print(embedding.parent.title)
-```
-
-### 3. Join Queries
-
-You can combine embedding queries with regular SQL queries using the relationship:
-
-```python
-results = (
-    session.query(BlogPost, BlogPost.content_embeddings)
-    .join(BlogPost.content_embeddings)
-    .filter(BlogPost.title.ilike("%search term%"))
-    .all()
-)
-
-for post, embedding in results:
-    print(f"Title: {post.title}")
-    print(f"Chunk: {embedding.chunk}")
-```
-
-## Working with alembic 
-
-### Excluding managed tables
-The `vectorizer_relationship` generates a new SQLAlchemy model, that is available under the attribute that you specify. If you are using alembic's autogenerate functionality to generate migrations, you will need to exclude these models from the autogenerate process.
-These are added to a list in your metadata called `pgai_managed_tables` and you can exclude them by adding the following to your `env.py`:
-
-```python
-def include_object(object, name, type_, reflected, compare_to):
-    if type_ == "table" and name in target_metadata.info.get("pgai_managed_tables", set()):
-        return False
-    return True
-
-context.configure(
-      connection=connection,
-      target_metadata=target_metadata,
-      include_object=include_object
-  )
-```
-
-This should now prevent alembic from generating tables for these models when you run `alembic revision --autogenerate`.
-
-
-### Creating vectorizers
-pgai provides native Alembic operations for managing vectorizers. For them to work you need to run `register_operations` in your env.py file. Which registers the pgai operations under the global op context:
-
-```python
-from pgai.alembic import register_operations
-
-register_operations()
-```
-
-Then you can use the `create_vectorizer` operation to create a vectorizer for your model. As well as the `drop_vectorizer` operation to remove it.
-
-```python
-from alembic import op
-from pgai.vectorizer.configuration import (
-    EmbeddingOpenaiConfig,
-    ChunkingCharacterTextSplitterConfig,
-    FormattingPythonTemplateConfig,
-    LoadingColumnConfig,
-    DestinationTableConfig
-)
-
-
-def upgrade() -> None:
-    op.create_vectorizer(
-        source="blog",
-        name="blog_content_embedder",  # Optional custom name for easier reference
-        destination=DestinationTableConfig(
-            destination='blog_embeddings'
-        ),
-        loading=LoadingColumnConfig(column_name='content'),
-        embedding=EmbeddingOpenaiConfig(
-            model='text-embedding-3-small',
-            dimensions=768
-        ),
-        chunking=ChunkingCharacterTextSplitterConfig(
-            chunk_size=800,
-            chunk_overlap=400,
-            separator='.',
-            is_separator_regex=False
-        ),
-        formatting=FormattingPythonTemplateConfig(template='$title - $chunk')
-    )
-
-
-def downgrade() -> None:
-    op.drop_vectorizer(name="blog_content_embedder", drop_all=True)
-```
-
-The `create_vectorizer` operation supports all configuration options available in the [SQL API](/docs/vectorizer/api-reference.md).
+- [SQLAlchemy integration](/docs/vectorizer/sqlalchemy-integration.md)
+- [Alembic integration](/docs/vectorizer/alembic-integration.md)

--- a/docs/vectorizer/sqlalchemy-integration.md
+++ b/docs/vectorizer/sqlalchemy-integration.md
@@ -1,0 +1,167 @@
+# SQLAlchemy Integration with pgai Vectorizer
+
+When creating vectorizers that use the `ai.destination_table` option, the vectorizer will create a new table in the database to store the vector embeddings. This guide describes how to integrate this new table,
+and it's relationship to your other tables, into your SQLAlchemy models.
+
+The heart of this integration is the `vectorizer_relationship` helper. Think of it as a normal SQLAlchemy [relationship](https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html), but with a preconfigured model instance under the hood.
+This allows you to easily query vector embeddings created by pgai using familiar SQLAlchemy patterns.
+
+## Installation
+
+To use the SQLAlchemy integration, install pgai with the SQLAlchemy extras:
+
+```bash
+pip install "pgai[sqlalchemy]"
+```
+
+## Basic Usage
+
+Here's a basic example of how to use the `vectorizer_relationship`:
+
+```python
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from pgai.sqlalchemy import vectorizer_relationship
+
+class Base(DeclarativeBase):
+    pass
+
+class BlogPost(Base):
+    __tablename__ = "blog_posts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str]
+    content: Mapped[str]
+
+    # Add vector embeddings for the content field
+    content_embeddings = vectorizer_relationship(
+        dimensions=768
+    )
+```
+
+Note if you work with alembics autogenerate functionality for migrations, also check the [Alembic integration guide](alembic-integration.md).
+
+### Semantic Search
+
+You can then perform semantic similarity search on the field using [pgvector-python's](https://github.com/pgvector/pgvector-python) distance functions:
+
+```python
+from sqlalchemy import func, text
+
+similar_posts = (
+    session.query(BlogPost.content_embeddings)
+    .order_by(
+        BlogPost.content_embeddings.embedding.cosine_distance(
+            func.ai.openai_embed(
+                "text-embedding-3-small",
+                "search query",
+                text("dimensions => 768")
+            )
+        )
+    )
+    .limit(5)
+    .all()
+)
+```
+
+Or if you already have the embeddings in your application:
+
+```python
+similar_posts = (
+    session.query(BlogPost.content_embeddings)
+    .order_by(
+        BlogPost.content_embeddings.embedding.cosine_distance(
+            [3, 1, 2]
+        )
+    )
+    .limit(5)
+    .all()
+)
+```
+
+## Configuration
+
+The `vectorizer_relationship` accepts the following parameters:
+
+- `dimensions` (int): The size of the embedding vector (required)
+- `target_schema` (str, optional): Override the schema for the embeddings table. If not provided, inherits from the parent model's schema
+- `target_table` (str, optional): Override the table name for embeddings. Default is `{table_name}_embedding_store`
+
+Additional parameters are simply forwarded to the underlying [SQLAlchemy relationship](https://docs.sqlalchemy.org/en/20/orm/relationships.html) so you can configure it as you desire.
+
+Think of the `vectorizer_relationship` as a normal SQLAlchemy relationship, but with a preconfigured model instance under the hood.
+The relationship into the other direction is also automatically set, if you want to change it's configuration you can set the
+`parent_kwargs`parameter. E.g. `parent_kwargs={"lazy": "joined"}` to configure eager loading.
+
+## Setting up the Vectorizer
+
+After defining your model, you need to create the vectorizer using pgai's SQL functions:
+
+```sql
+SELECT ai.create_vectorizer(
+    'blog_posts'::regclass,
+    loading => ai.loading_column('content'),
+    embedding => ai.embedding_openai('text-embedding-3-small', 768),
+    chunking => ai.chunking_recursive_character_text_splitter(
+        50,  -- chunk_size
+        10   -- chunk_overlap
+    )
+);
+```
+
+We recommend adding this to a migration script and run it via alembic (see our [alembic integration docs](alembic-integration.md) for more details).
+
+
+## Querying Embeddings
+
+The `vectorizer_relationship` provides several ways to work with embeddings:
+
+### 1. Direct Access to Embeddings
+
+If you access the class property of your model the `vectorizer_relationship` provide a SQLAlchemy model that you can query directly:
+
+```python
+# Get all embeddings
+embeddings = session.query(BlogPost.content_embeddings).all()
+
+# Access embedding properties
+for embedding in embeddings:
+    print(embedding.embedding)  # The vector embedding
+    print(embedding.chunk)      # The text chunk
+```
+The model will have the primary key fields of the parent model as well as the following fields:
+- `chunk` (str): The text chunk that was embedded
+- `embedding` (Vector): The vector embedding
+- `chunk_seq` (int): The sequence number of the chunk
+- `embedding_uuid` (str): The UUID of the embedding
+- `parent` (ParentModel): The parent model instance
+
+### 2. Relationship Access
+
+
+```python
+blog_post = session.query(BlogPost).first()
+for embedding in blog_post.content_embeddings:
+    print(embedding.chunk)
+```
+Access the original posts through the parent relationship
+```python
+for embedding in similar_posts:
+    print(embedding.parent.title)
+```
+
+### 3. Join Queries
+
+You can combine embedding queries with regular SQL queries using the relationship:
+
+```python
+results = (
+    session.query(BlogPost, BlogPost.content_embeddings)
+    .join(BlogPost.content_embeddings)
+    .filter(BlogPost.title.ilike("%search term%"))
+    .all()
+)
+
+for post, embedding in results:
+    print(f"Title: {post.title}")
+    print(f"Chunk: {embedding.chunk}")
+```


### PR DESCRIPTION
Separate the various Python integrations into separate files. This makes it easier to discover and link to the right thing.