### PR TITLE
feat: support aggregate functions

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/describe.py
+++ b/projects/pgai/pgai/semantic_catalog/describe.py
@@ -159,7 +159,6 @@ async def find_procedures(
             and n.nspname != 'timescaledb_experimental'
             and n.nspname != 'timescaledb_information'
             and n.nspname != 'toolkit_experimental'
-            and p.prokind != 'a'
             {filters}
         """).format(filters=combined_filters)
         await cur.execute(query, params)

--- a/projects/pgai/tests/semantic_catalog/data/cagg.sql
+++ b/projects/pgai/tests/semantic_catalog/data/cagg.sql
@@ -32,3 +32,13 @@ SELECT create_hypertable('postgres_air.hypertable_test', by_range('time'));
 SELECT add_dimension('postgres_air.hypertable_test', by_hash('location', 2));
 SELECT add_dimension('postgres_air.hypertable_test', by_range('time_received', INTERVAL '1 day'));
 SELECT add_dimension('postgres_air.hypertable_test', by_range('params', INTERVAL '1 day', partition_func => 'public.hypertable_test_func'));
+
+CREATE AGGREGATE postgres_air.unsafe_sum (float8)
+(
+    stype = float8,
+    sfunc = float8pl,
+    mstype = float8,
+    msfunc = float8pl,
+    minvfunc = float8mi,
+    initcond = 10
+);

--- a/projects/pgai/tests/semantic_catalog/data/procedures.json
+++ b/projects/pgai/tests/semantic_catalog/data/procedures.json
@@ -25,5 +25,17 @@
       "integer",
       "pg_catalog.text"
     ]
+  },
+  "unsafe_sum": {
+    "classid": 1255,
+    "objid": 24005,
+    "schema_name": "postgres_air",
+    "proc_name": "unsafe_sum",
+    "kind": "aggregate",
+    "identity_args": "double precision",
+    "definition": "CREATE OR REPLACE AGGREGATE FUNCTION postgres_air.unsafe_sum(double precision) (\n  sfunc = float8pl,\n  stype = float8,\n  msfunc = float8pl,\n  mstype = float8,\n  minvfunc = float8mi,\n  initcond = 10\n)",
+    "objargs": [
+      "double precision"
+    ]
   }
 }

--- a/projects/pgai/tests/semantic_catalog/data/render_description_to_sql.expected
+++ b/projects/pgai/tests/semantic_catalog/data/render_description_to_sql.expected
@@ -107,4 +107,5 @@ select ai.sc_set_view_col_desc(42, 102, 1, 'postgres_air', 'passenger_details', 
 select ai.sc_set_view_col_desc(42, 102, 2, 'postgres_air', 'passenger_details', 'last_name', 'this is a description for column last_name', 'my_catalog');
 select ai.sc_set_view_col_desc(42, 102, 3, 'postgres_air', 'passenger_details', 'booking_ref', 'this is a description for column booking_ref', 'my_catalog');
 select ai.sc_set_proc_desc(666, 0, 'postgres_air', 'advance_air_time', '{integer,pg_catalog.text,boolean}', 'this is a description for procedure advance_air_time', 'my_catalog');
-select ai.sc_set_proc_desc(666, 1, 'postgres_air', 'update_flight_status', '{integer,pg_catalog.text}', 'this is a description for procedure update_flight_status', 'my_catalog');
+select ai.sc_set_agg_desc(666, 1, 'postgres_air', 'unsafe_sum', '{"double precision"}', 'this is a description for aggregate unsafe_sum', 'my_catalog');
+select ai.sc_set_proc_desc(666, 2, 'postgres_air', 'update_flight_status', '{integer,pg_catalog.text}', 'this is a description for procedure update_flight_status', 'my_catalog');

--- a/projects/pgai/tests/semantic_catalog/data/render_procedures.expected
+++ b/projects/pgai/tests/semantic_catalog/data/render_procedures.expected
@@ -38,6 +38,17 @@ $procedure$
 ;
 </procedure>
 
+<aggregate id="0">
+CREATE OR REPLACE AGGREGATE FUNCTION postgres_air.unsafe_sum(double precision) (
+  sfunc = float8pl,
+  stype = float8,
+  msfunc = float8pl,
+  mstype = float8,
+  minvfunc = float8mi,
+  initcond = 10
+);
+</aggregate>
+
 <procedure id="0">
 CREATE OR REPLACE PROCEDURE postgres_air.update_flight_status(IN flight_id integer, IN status text)
  LANGUAGE plpgsql

--- a/projects/pgai/tests/semantic_catalog/test_describe.py
+++ b/projects/pgai/tests/semantic_catalog/test_describe.py
@@ -39,7 +39,7 @@ ALL_TABLES: set[str] = {
 
 ALL_VIEWS: set[str] = {"events_daily", "flight_summary", "passenger_details"}
 
-ALL_PROCS: set[str] = {"advance_air_time", "update_flight_status"}
+ALL_PROCS: set[str] = {"advance_air_time", "unsafe_sum", "update_flight_status"}
 
 
 async def get_table_names(con: psycopg.AsyncConnection, oids: list[int]) -> set[str]:
@@ -187,10 +187,13 @@ async def test_find_procs(container: PostgresContainer):
         ({"exclude_schema": "^emp", "include_schema": "_air$"}, ALL_PROCS),
         ({"exclude_schema": "_air$", "include_schema": "^emp"}, EMPTY_SET),
         ({"include_proc": "advance.*"}, {"advance_air_time"}),
-        ({"include_proc": "(advance_air_time|update_flight_status)"}, ALL_PROCS),
+        (
+            {"include_proc": "(advance_air_time|unsafe_sum|update_flight_status)"},
+            ALL_PROCS,
+        ),
         (
             {"exclude_proc": "advance_air_time", "include_schema": "postgres_air"},
-            {"update_flight_status"},
+            {"update_flight_status", "unsafe_sum"},
         ),
         ({"include_proc": "bob"}, EMPTY_SET),
         ({"include_proc": "^advance"}, {"advance_air_time"}),
@@ -198,7 +201,7 @@ async def test_find_procs(container: PostgresContainer):
         ({"include_schema": "^postgres_air$", "exclude_proc": ".*"}, EMPTY_SET),
         ({"exclude_schema": "^public$", "exclude_proc": ".*"}, EMPTY_SET),
         (
-            {"exclude_schema": "^public$", "include_proc": "^u"},
+            {"exclude_schema": "^public$", "include_proc": "^up"},
             {"update_flight_status"},
         ),
     ]

--- a/projects/pgai/tests/semantic_catalog/test_loader.py
+++ b/projects/pgai/tests/semantic_catalog/test_loader.py
@@ -50,9 +50,9 @@ async def test_load_procedures(container: PostgresContainer):
     ) as con:
         for proc_name, expected in get_procedure_dict().items():
             oids = await describe.find_procedures(con, include_proc=f"^{proc_name}$")
-            assert len(oids) == 1
+            assert len(oids) == 1, f"no oids found for {proc_name}"
             actual = await loader.load_procedures(con, oids)
-            assert len(actual) == 1
+            assert len(actual) == 1, f"no procedure found for {proc_name}"
             actual = actual[0]
             # classid and objid will change. don't compare
             actual.classid = expected.classid


### PR DESCRIPTION
PR adds support for loading and rendering aggregate functions. The big annoyance is that as `pg_get_functiondef` errors out on aggregate functions, we need to manually put together the create DDL for the function using stuff from the [`pg_aggregate`](https://www.postgresql.org/docs/current/catalog-pg-aggregate.html) table.