### PR TITLE
fix: disable logging from sentence-transformers

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/vectorizer/sentence_tranformers.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/sentence_tranformers.py
@@ -1,4 +1,6 @@
+import logging
 from collections.abc import Sequence
+from contextlib import contextmanager
 
 import numpy as np
 import numpy.typing as npt
@@ -8,6 +10,26 @@ from pgai.semantic_catalog.vectorizer import SentenceTransformersConfig
 from pgai.semantic_catalog.vectorizer.models import EmbedRow
 
 
+@contextmanager
+def disable_logging():
+    """
+    Disable logging for the sentence_transformers and transformers_modules
+    libraries.
+    """
+    st_logger = logging.getLogger("sentence_transformers")
+    st_prev_level = st_logger.level
+    st_logger.setLevel(logging.ERROR)
+    t_logger = logging.getLogger("transformers_modules")
+    t_prev_level = t_logger.level
+    t_logger.setLevel(logging.ERROR)
+
+    try:
+        yield
+    finally:
+        st_logger.setLevel(st_prev_level)
+        t_logger.setLevel(t_prev_level)
+
+
 async def embed_batch(
     config: SentenceTransformersConfig, batch: list[EmbedRow]
 ) -> None:
@@ -15,19 +37,20 @@ async def embed_batch(
         config.model, trust_remote_code=True
     )  # TODO: configurable?
     sentences: list[str] = [x.content for x in batch]
-    results: npt.NDArray[np.float64] = st.encode(  # pyright: ignore [reportUnknownMemberType]
-        sentences=sentences,
-        prompt_name=None,
-        prompt=None,
-        batch_size=len(batch),
-        show_progress_bar=False,
-        output_value="sentence_embedding",
-        precision="float32",
-        convert_to_numpy=True,
-        convert_to_tensor=False,
-        device=None,
-        normalize_embeddings=True,
-    )
+    with disable_logging():
+        results: npt.NDArray[np.float64] = st.encode(  # pyright: ignore [reportUnknownMemberType]
+            sentences=sentences,
+            prompt_name=None,
+            prompt=None,
+            batch_size=len(batch),
+            show_progress_bar=False,
+            output_value="sentence_embedding",
+            precision="float32",
+            convert_to_numpy=True,
+            convert_to_tensor=False,
+            device=None,
+            normalize_embeddings=True,
+        )
     assert len(results) == len(batch)
     for i, row in enumerate(results):
         batch[i].vector = list(row)
@@ -40,18 +63,19 @@ async def embed_query(
         config.model, trust_remote_code=True
     )  # TODO: configurable?
     sentences: list[str] = [query]
-    results: npt.NDArray[np.float64] = st.encode(  # pyright: ignore [reportUnknownMemberType]
-        sentences=sentences,
-        prompt_name=None,
-        prompt=None,
-        batch_size=1,
-        show_progress_bar=False,
-        output_value="sentence_embedding",
-        precision="float32",
-        convert_to_numpy=True,
-        convert_to_tensor=False,
-        device=None,
-        normalize_embeddings=True,
-    )
+    with disable_logging():
+        results: npt.NDArray[np.float64] = st.encode(  # pyright: ignore [reportUnknownMemberType]
+            sentences=sentences,
+            prompt_name=None,
+            prompt=None,
+            batch_size=1,
+            show_progress_bar=False,
+            output_value="sentence_embedding",
+            precision="float32",
+            convert_to_numpy=True,
+            convert_to_tensor=False,
+            device=None,
+            normalize_embeddings=True,
+        )
     assert len(results) == 1
     return list(results[0])


### PR DESCRIPTION
PR largely disables logging from the `sentence-transformers` library as it's mostly "noise" in terms of our usage and what we show to consumers. We will still log errors from the library though, though I'm unsure exactly if/when it might do that.

Before:
```
$ uv run pgai semantic-catalog load -f foo.sql
[04/30/25 08:44:17] INFO     2025-04-30 08:44:17,704 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: mps                                                                                     SentenceTransformer.py:211
                    INFO     2025-04-30 08:44:17,706 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: nomic-ai/nomic-embed-text-v1.5                                              SentenceTransformer.py:219
[04/30/25 08:44:21] WARNING  2025-04-30 08:44:21,376 - transformers_modules.nomic-ai.nomic-bert-2048.7710840340a098cfb869c4f65e87cf2b1b70caca.modeling_hf_nomic_bert - WARNING - <All keys matched successfully>        modeling_hf_nomic_bert.py:466
[04/30/25 08:44:22] INFO     2025-04-30 08:44:22,474 - sentence_transformers.SentenceTransformer - INFO - Use pytorch device_name: mps                                                                                     SentenceTransformer.py:211
                    INFO     2025-04-30 08:44:22,475 - sentence_transformers.SentenceTransformer - INFO - Load pretrained SentenceTransformer: nomic-ai/nomic-embed-text-v1.5                                              SentenceTransformer.py:219
[04/30/25 08:44:25] WARNING  2025-04-30 08:44:25,937 - transformers_modules.nomic-ai.nomic-bert-2048.7710840340a098cfb869c4f65e87cf2b1b70caca.modeling_hf_nomic_bert - WARNING - <All keys matched successfully>        modeling_hf_nomic_bert.py:466
$
```

After:
```
$ uv run pgai semantic-catalog load -f foo.sql
$
```