### PR TITLE
fix: set config_type in embedding_config_from_dict

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/vectorizer.py
@@ -79,6 +79,7 @@ EmbeddingConfig = Annotated[
 
 
 def embedding_config_from_dict(config: dict[str, Any]) -> EmbeddingConfig:
+    config = {**config, "embedding_type": "embedding"}
     assert "implementation" in config
     match config["implementation"]:
         case "sentence_transformers":


### PR DESCRIPTION
PR makes it so that don't need to pass `"config_type": "embedding"` as part of the dict passed to `embedding_config_from_dict` as it feels redundant given the name of the function, and that these configs only accept `config_type: "embedding"`, and that the parameters I pass into the function do not really apply to other configs we have. 