### PR TITLE
fix: make describe --append a flag

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -330,8 +330,7 @@ def semantic_catalog():
 @click.option(
     "-a",
     "--append",
-    type=click.BOOL,
-    default=False,
+    is_flag=True,
     help="Append to the output file instead of overwriting it.",
 )
 @click.option(


### PR DESCRIPTION
PR makes the `--append` option to `describe` a flag, instead of having user pass in `true/false` explicitly. I cannot really see a reason why someone would ever pass in `--append false` vs just not having the flag, and then this makes it easier to actually use `--append` for the true case.