### PR TITLE
fix: improve sc error message when pgai not installed

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
+++ b/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
@@ -343,7 +343,24 @@ class SemanticCatalog:
         await async_export_to_yaml(yaml, load_from_catalog(catalog_con, self.id))
 
 
+async def _check_installed(con: CatalogConnection) -> None:
+    async with con.cursor() as cur:
+        await cur.execute(
+            """\
+            select count(*)
+            from information_schema.tables
+            where table_schema = %s and table_name = %s
+        """,
+            ("ai", "semantic_catalog"),
+        )
+        row = await cur.fetchone()
+        assert (
+            row is not None and row[0] > 0
+        ), "Semantic catalog is not installed, please run: pgai semantic-catalog create"
+
+
 async def from_id(con: CatalogConnection, id: int) -> SemanticCatalog:
+    await _check_installed(con)
     async with con.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """\
@@ -360,6 +377,7 @@ async def from_id(con: CatalogConnection, id: int) -> SemanticCatalog:
 
 
 async def from_name(con: CatalogConnection, catalog_name: str) -> SemanticCatalog:
+    await _check_installed(con)
     async with con.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """\

--- a/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
+++ b/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
@@ -343,33 +343,22 @@ class SemanticCatalog:
         await async_export_to_yaml(yaml, load_from_catalog(catalog_con, self.id))
 
 
-async def _check_installed(con: CatalogConnection) -> None:
-    async with con.cursor() as cur:
-        await cur.execute(
-            """\
-            select count(*)
-            from information_schema.tables
-            where table_schema = %s and table_name = %s
-        """,
-            ("ai", "semantic_catalog"),
-        )
-        row = await cur.fetchone()
-        assert (
-            row is not None and row[0] > 0
-        ), "Semantic catalog is not installed, please run: pgai semantic-catalog create"
-
-
 async def from_id(con: CatalogConnection, id: int) -> SemanticCatalog:
-    await _check_installed(con)
     async with con.cursor(row_factory=dict_row) as cur:
-        await cur.execute(
-            """\
-            select id, catalog_name
-            from ai.semantic_catalog
-            where id = %s
-        """,
-            (id,),
-        )
+        try:
+            await cur.execute(
+                """\
+                select id, catalog_name
+                from ai.semantic_catalog
+                where id = %s
+            """,
+                (id,),
+            )
+        except psycopg.errors.UndefinedTable:
+            raise RuntimeError(
+                "Semantic catalog is not installed, please run: "
+                + "pgai semantic-catalog create"
+            ) from None
         row = await cur.fetchone()
         if row is None:
             raise RuntimeError(f"No semantic catalog found with id: {id}")
@@ -377,16 +366,21 @@ async def from_id(con: CatalogConnection, id: int) -> SemanticCatalog:
 
 
 async def from_name(con: CatalogConnection, catalog_name: str) -> SemanticCatalog:
-    await _check_installed(con)
     async with con.cursor(row_factory=dict_row) as cur:
-        await cur.execute(
-            """\
-            select id, catalog_name
-            from ai.semantic_catalog
-            where catalog_name = %s
-        """,
-            (catalog_name,),
-        )
+        try:
+            await cur.execute(
+                """\
+                select id, catalog_name
+                from ai.semantic_catalog
+                where catalog_name = %s
+            """,
+                (catalog_name,),
+            )
+        except psycopg.errors.UndefinedTable:
+            raise RuntimeError(
+                "Semantic catalog is not installed, please run: "
+                + "pgai semantic-catalog create"
+            ) from None
         row = await cur.fetchone()
         if row is None:
             raise RuntimeError(
@@ -397,10 +391,16 @@ async def from_name(con: CatalogConnection, catalog_name: str) -> SemanticCatalo
 
 async def list_semantic_catalogs(con: CatalogConnection) -> list[SemanticCatalog]:
     async with con.cursor(row_factory=dict_row) as cur:
-        await cur.execute("""\
-            select id, catalog_name
-            from ai.semantic_catalog
-        """)
+        try:
+            await cur.execute("""\
+                select id, catalog_name
+                from ai.semantic_catalog
+            """)
+        except psycopg.errors.UndefinedTable:
+            raise RuntimeError(
+                "Semantic catalog is not installed, please run: "
+                + "pgai semantic-catalog create"
+            ) from None
         results: list[SemanticCatalog] = []
         for row in await cur.fetchall():
             results.append(SemanticCatalog(row["id"], row["catalog_name"]))


### PR DESCRIPTION
PR improves it so that when trying to run a command that requires the semantic catalog when pgai hasn't been installed, so that instead of the seeing the following exception message:

```
psycopg.errors.UndefinedTable: relation "ai.semantic_catalog" does not exist
LINE 2:             from ai.semantic_catalog
```

will now see:

```
AssertionError: Semantic catalog is not installed, please run: pgai semantic-catalog create
```

which provides actionable advice to the user on how to fix their issue.