### PR TITLE
feat: add sc list function for sql_examples and facts

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
+++ b/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
@@ -4,7 +4,7 @@ from typing import Any, TextIO
 
 import psycopg
 from psycopg.rows import dict_row
-from psycopg.sql import SQL, Composable
+from psycopg.sql import SQL, Composable, Identifier
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import Usage, UsageLimits
@@ -179,6 +179,24 @@ class SemanticCatalog:
             con, self.id, embedding_name, emb_cfg, query, limit
         )
 
+    async def list_sql_examples(
+        self,
+        con: CatalogConnection,
+    ) -> list[SQLExample]:
+        async with con.cursor(row_factory=dict_row) as cur:
+            sql = SQL("""\
+                select x.*
+                from ai.{table} x
+                order by x.id
+            """).format(
+                table=Identifier(f"semantic_catalog_sql_{self.id}"),
+            )
+            await cur.execute(sql)
+            results: list[SQLExample] = []
+            for row in await cur.fetchall():
+                results.append(SQLExample(**row))
+        return results
+
     async def search_sql_examples(
         self,
         con: CatalogConnection,
@@ -195,6 +213,24 @@ class SemanticCatalog:
         return await search.search_sql_examples(
             con, self.id, embedding_name, emb_cfg, query, limit
         )
+
+    async def list_facts(
+        self,
+        con: CatalogConnection,
+    ) -> list[Fact]:
+        async with con.cursor(row_factory=dict_row) as cur:
+            sql = SQL("""\
+                select x.*
+                from ai.{table} x
+                order by x.id
+            """).format(
+                table=Identifier(f"semantic_catalog_fact_{self.id}"),
+            )
+            await cur.execute(sql)
+            results: list[Fact] = []
+            for row in await cur.fetchall():
+                results.append(Fact(**row))
+        return results
 
     async def search_facts(
         self,

--- a/projects/pgai/tests/semantic_catalog/test_search.py
+++ b/projects/pgai/tests/semantic_catalog/test_search.py
@@ -113,6 +113,19 @@ async def test_search_obj_ollama(container: PostgresContainer) -> None:
         assert obj_desc.description is not None
 
 
+async def test_list_sql(container: PostgresContainer) -> None:
+    async with await psycopg.AsyncConnection.connect(
+        container.connection_string(database=DATABASE)
+    ) as con:
+        sc = await semantic_catalog.from_name(con, "default")
+        sql_examples = await sc.list_sql_examples(con)
+        assert len(sql_examples) > 0
+        sql_example = sql_examples[0]
+        assert (
+            sql_example.description == "Delayed flights are indicated by their status"
+        )
+
+
 async def test_search_sql_sentence_transformers(container: PostgresContainer) -> None:
     async with await psycopg.AsyncConnection.connect(
         container.connection_string(database=DATABASE)
@@ -168,6 +181,20 @@ async def test_search_sql_ollama(container: PostgresContainer) -> None:
         sql_example = sql_examples[0]
         assert (
             sql_example.description == "Delayed flights are indicated by their status"
+        )
+
+
+async def test_list_facts(container: PostgresContainer) -> None:
+    async with await psycopg.AsyncConnection.connect(
+        container.connection_string(database=DATABASE)
+    ) as con:
+        sc = await semantic_catalog.from_name(con, "default")
+        facts = await sc.list_facts(con)
+        assert len(facts) > 0
+        fact = facts[0]
+        assert (
+            fact.description
+            == "The postgres_air.airport.iso_region values are in uppercase."
         )
 
 


### PR DESCRIPTION
PR adds the following methods to the semantic catalog:

* `list_sql_examples`
* `list_facts`

This makes it easy to get all of these objects in the database. I plan to do a follow-up PR for `list_objects`, though I plan to add some additional arguments to filter to specific types of database objects.