### PR TITLE
fix: missing implementation error when doing sc create

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -661,7 +661,7 @@ def create(
     from pgai.semantic_catalog.vectorizer import embedding_config_from_dict
 
     d = dict(
-        provider=provider.lower(),
+        implementation=provider.lower(),
         model=str(model),
         dimensions=int(vector_dimensions),
     )


### PR DESCRIPTION
PR fixes doing `pgai semantic-catalog create`, such that the catalog will be created and you will not see the following error:

```
AssertionError: config is missing implementation specification
```