### PR TITLE
ci: install pgai when running dev env through compose-dev.yaml

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,39 +88,11 @@ The CI pipeline will check:
 Remember to always pull the latest changes before starting new work.
 
 ## Testing features
-If there is a feature in main that isn't released yet
-you can create a docker-compose.yml that looks like this:
-```yaml
-name: pgai
-services:
-  db:
-    build:
-      context: projects/extension
-      dockerfile: Dockerfile
-      target: pgai-test-db
-    environment:
-      POSTGRES_PASSWORD: postgres
-    ports:
-      - "5432:5432"
-    volumes:
-      - data:/home/postgres/pgdata/data
-    command: [ "-c", "ai.ollama_host=http://ollama:11434" ]
-  vectorizer-worker:
-    build:
-      context: projects/pgai
-      dockerfile: Dockerfile
-    environment:
-      PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
-      OLLAMA_HOST: http://ollama:11434
-    command: [ "--poll-interval", "5s", "--log-level", "DEBUG" ]
-  ollama:
-    image: ollama/ollama
-volumes:
-  data:
-```
+If there is a feature in main that isn't released yet,
+please set up your [Docker development environment](/projects/pgai/DEVELOPMENT.md#docker-development-environment).
 
-This will build the vectorizer-worker and a database image with pgai
-installed from your repository state.
+This will build the vectorizer-worker and a database image with the pgai
+library installed from your repository state.
 You can then play around with the latest and greatest changes.
 
 

--- a/projects/pgai/DEVELOPMENT.md
+++ b/projects/pgai/DEVELOPMENT.md
@@ -101,7 +101,8 @@ just pgai type-check
 
 The following lines provide instructions for setting up and running the `pgai` development environment using Docker Compose. The setup consists of two primary services:
 
-- **db**: A PostgreSQL database instance with persistent storage and the `pgai` extension preloaded. Built from source using the [extension's Dockerfile](../extension/Dockerfile).
+- **db**: A PostgreSQL database instance with persistent storage. Built from source using the [extension's Dockerfile](../extension/Dockerfile).
+- **pgai-installer**: An ephemeral service that installs `pgai` in the database.
 - **vectorizer-worker**: The vectorizer worker service that connects to the PostgreSQL database and performs vectorization tasks. Built from source using the [Dockerfile](./Dockerfile).
 
 Files involved in the setup:
@@ -144,22 +145,6 @@ Alternatively, you can connect using any other client by specifying the followin
 psql 'postgresql://postgres:postgres@localhost'
 ```
 
-> [!IMPORTANT]  
-> Even though the pgai extension is loaded, it is not installed by default. Read below.
-
-#### Installing the pgai extension
-To install the `pgai` extension, connect to the database and run:
-
-```sql
-CREATE EXTENSION IF NOT EXISTS ai cascade;
-```
-
-Alternatively, you can run the following command from the host machine:
-
-```sh
-docker compose --file compose-dev.yaml exec -t db psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS ai cascade;"
-```
-`
 ### Viewing logs
 To see logs for all services:
 

--- a/projects/pgai/compose-dev.yaml
+++ b/projects/pgai/compose-dev.yaml
@@ -16,10 +16,27 @@ services:
         required: false
       - path: ./db.env
         required: false
+  pgai-installer:
+    build: .
+    depends_on:
+      - db
+    entrypoint: sh
+    command:
+      - -c
+      - |
+        for i in $(seq 1 10); do
+          echo "Attempt $$i: installing pgai..."
+          # always overwriting previous installation here.
+          python -m pgai install -d postgres://postgres:postgres@db:5432/postgres && exit 0
+          echo "Failed. Retrying in 1s..."
+          sleep 1
+        done
+        echo "❌ pgai install failed after 10 attempts."
+        exit 1
   vectorizer-worker:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: .
+    depends_on:
+      - pgai-installer
     environment:
       PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:postgres@db:5432/postgres
     env_file:

--- a/projects/pgai/pgai/vectorizer/generate/docker-compose.yaml
+++ b/projects/pgai/pgai/vectorizer/generate/docker-compose.yaml
@@ -10,6 +10,6 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - data:/home/postgres/pgdata/data
+      - data:/var/lib/postgresql/data
 volumes:
   data:


### PR DESCRIPTION
We didn't update the `compose-dev.yaml` file since the repackaging. That means we were not installing `pgai` in the DB and we were still asking the user to install the extension.

Additionally, we were using the wrong postgres PGDATA path. In particular, we were setting `/home/postgres/pgdata/data` instead of the default in postgres `/var/lib/postgresql/data` because is the one we use in [timescaledb-docker-ha](https://github.com/timescale/timescaledb-docker-ha/blob/master/Dockerfile#L437). 
That means data was never persisted in the host volume.