### PR TITLE
feat: add support for named vectorizers to ai.vectorizer_errors

### DIFF
--- a/projects/pgai/db/sql/idempotent/999-privileges.sql
+++ b/projects/pgai/db/sql/idempotent/999-privileges.sql
@@ -4,6 +4,7 @@ begin
     if not admin then
         execute 'grant usage, create on schema ai to ' || to_user;
         execute 'grant select, insert, update, delete on table ai.vectorizer to ' || to_user;
+        execute 'grant select on ai._vectorizer_errors to ' || to_user;
         execute 'grant select on ai.vectorizer_errors to ' || to_user;
         execute 'grant select on ai.vectorizer_status to ' || to_user;
         execute 'grant select, usage on sequence ai.vectorizer_id_seq to ' || to_user;
@@ -13,6 +14,7 @@ begin
         execute 'grant all privileges on table ai.pgai_lib_version to ' || to_user;
         execute 'grant all privileges on table ai.pgai_lib_feature_flag to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer to ' || to_user;
+        execute 'grant all privileges on table ai._vectorizer_errors to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer_errors to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer_status to ' || to_user;
         execute 'grant all privileges on sequence ai.vectorizer_id_seq to ' || to_user;

--- a/projects/pgai/db/sql/incremental/030-add_vectorizer_errors_view.sql
+++ b/projects/pgai/db/sql/incremental/030-add_vectorizer_errors_view.sql
@@ -1,0 +1,42 @@
+-- rename the ai.vectorizer_errors table to ai._vectorizer_errors
+alter table ai.vectorizer_errors rename to _vectorizer_errors;
+
+-- rename the existing index on the ai.vectorizer_error so it follows the right naming convention (adds the _ prefix)
+-- this is not strictly necessary, but it is a good practice to keep the naming consistent
+alter index ai.vectorizer_errors_id_recorded_idx rename to _vectorizer_errors_id_recorded_idx;
+
+-- create a view including vectorizer name
+create or replace view ai.vectorizer_errors as
+select 
+  ve.*,
+  v.name
+from
+  ai._vectorizer_errors ve
+  left join ai.vectorizer v on ve.id = v.id;
+
+
+-- grant privileges on new ai.vectorizer_errors view
+do language plpgsql $block$
+declare
+    to_user text;
+    priv_type text;
+    with_grant text;
+    rec record;
+begin
+    -- find all users that have permissions on old ai.vectorizer_errors table and grant them to the view
+    for rec in
+        select distinct grantee as username, privilege_type, is_grantable
+        from information_schema.role_table_grants
+        where table_schema = 'ai'
+        and table_name = '_vectorizer_errors'
+    loop
+        to_user := rec.username;
+        priv_type := rec.privilege_type;
+        with_grant := '';
+        if rec.is_grantable then
+           with_grant := ' WITH GRANT OPTION';
+        end if;
+        execute format('GRANT %s ON ai.vectorizer_errors TO %I %s', priv_type, to_user, with_grant);
+    end loop;
+end
+$block$;

--- a/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
+++ b/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
@@ -144,6 +144,20 @@ def test_named_vectorizer():
             vectorizer_name = cur.fetchone()[0]
             assert vectorizer_name == "website_blog_embedding1"
 
+            # Test fetch errors by vectorizer name
+            cur.execute(
+                "insert into ai._vectorizer_errors (id, message) values (%s, %s)",
+                (vectorizer_id_2, "test error message"),
+            )
+
+            cur.execute(
+                "select * from ai.vectorizer_errors where name = %s",
+                (vectorizer_name,),
+            )
+
+            error = cur.fetchone()
+            assert error.message == "test error message"
+
             # create a vectorizer with no name check default name
             cur.execute("""
                select ai.create_vectorizer

--- a/projects/pgai/pgai/data/ai.sql
+++ b/projects/pgai/pgai/data/ai.sql
@@ -1103,6 +1103,74 @@ begin
 end;
 $outer_migration_block$;
 
+-------------------------------------------------------------------------------
+-- 030-add_vectorizer_errors_view.sql
+do $outer_migration_block$ /*030-add_vectorizer_errors_view.sql*/
+declare
+    _sql text;
+    _migration record;
+    _migration_name text = $migration_name$030-add_vectorizer_errors_view.sql$migration_name$;
+    _migration_body text =
+$migration_body$
+-- rename the ai.vectorizer_errors table to ai._vectorizer_errors
+alter table ai.vectorizer_errors rename to _vectorizer_errors;
+
+-- rename the existing index on the ai.vectorizer_error so it follows the right naming convention (adds the _ prefix)
+-- this is not strictly necessary, but it is a good practice to keep the naming consistent
+alter index ai.vectorizer_errors_id_recorded_idx rename to _vectorizer_errors_id_recorded_idx;
+
+-- create a view including vectorizer name
+create or replace view ai.vectorizer_errors as
+select 
+  ve.*,
+  v.name
+from
+  ai._vectorizer_errors ve
+  left join ai.vectorizer v on ve.id = v.id;
+
+
+-- grant privileges on new ai.vectorizer_errors view
+do language plpgsql $block$
+declare
+    to_user text;
+    priv_type text;
+    with_grant text;
+    rec record;
+begin
+    -- find all users that have permissions on old ai.vectorizer_errors table and grant them to the view
+    for rec in
+        select distinct grantee as username, privilege_type, is_grantable
+        from information_schema.role_table_grants
+        where table_schema = 'ai'
+        and table_name = '_vectorizer_errors'
+    loop
+        to_user := rec.username;
+        priv_type := rec.privilege_type;
+        with_grant := '';
+        if rec.is_grantable then
+           with_grant := ' WITH GRANT OPTION';
+        end if;
+        execute format('GRANT %s ON ai.vectorizer_errors TO %I %s', priv_type, to_user, with_grant);
+    end loop;
+end
+$block$;
+$migration_body$;
+begin
+    select * into _migration from ai.pgai_lib_migration where "name" operator(pg_catalog.=) _migration_name;
+    if _migration is not null then
+        raise notice 'migration %s already applied. skipping.', _migration_name;
+        if _migration.body operator(pg_catalog.!=) _migration_body then
+            raise warning 'the contents of migration "%s" have changed', _migration_name;
+        end if;
+        return;
+    end if;
+    _sql = pg_catalog.format(E'do /*%s*/ $migration_body$\nbegin\n%s\nend;\n$migration_body$;', _migration_name, _migration_body);
+    execute _sql;
+    insert into ai.pgai_lib_migration ("name", body, applied_at_version)
+    values (_migration_name, _migration_body, $version$__version__$version$);
+end;
+$outer_migration_block$;
+
 --------------------------------------------------------------------------------
 -- 001-chunking.sql
 
@@ -4222,6 +4290,7 @@ begin
     if not admin then
         execute 'grant usage, create on schema ai to ' || to_user;
         execute 'grant select, insert, update, delete on table ai.vectorizer to ' || to_user;
+        execute 'grant select on ai._vectorizer_errors to ' || to_user;
         execute 'grant select on ai.vectorizer_errors to ' || to_user;
         execute 'grant select on ai.vectorizer_status to ' || to_user;
         execute 'grant select, usage on sequence ai.vectorizer_id_seq to ' || to_user;
@@ -4231,6 +4300,7 @@ begin
         execute 'grant all privileges on table ai.pgai_lib_version to ' || to_user;
         execute 'grant all privileges on table ai.pgai_lib_feature_flag to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer to ' || to_user;
+        execute 'grant all privileges on table ai._vectorizer_errors to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer_errors to ' || to_user;
         execute 'grant all privileges on table ai.vectorizer_status to ' || to_user;
         execute 'grant all privileges on sequence ai.vectorizer_id_seq to ' || to_user;

--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -125,7 +125,7 @@ class Vectorizer(BaseModel):
         source_pk (list[PkAtt]): List of primary key attributes from the source table.
         errors_schema (str): The schema where the error log is saved. Default is "ai".
         errors_table (str): The table where errors are logged.
-            Default is "vectorizer_errors".
+            Default is "_vectorizer_errors".
     """
 
     id: int
@@ -137,7 +137,7 @@ class Vectorizer(BaseModel):
     source_pk: list[PkAtt]
     queue_failed_table: str | None = None
     errors_schema: str = "ai"
-    errors_table: str = "vectorizer_errors"
+    errors_table: str = "_vectorizer_errors"
     schema_: str = Field(alias="schema", default="ai")
     table: str = "vectorizer"
 


### PR DESCRIPTION
This is an improved version of https://github.com/timescale/pgai/pull/683, which was reverted.
This PR considers retrocompatibility with previous versions that have `ai.vectorizer_errors` as table.