### PR TITLE
fix: default value of mode param for sc fix

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -1579,7 +1579,7 @@ def fix(
     db_url: str | None,
     catalog_db_url: str | None,
     catalog_name: str | None,
-    mode: str = "names-from-ids",
+    mode: str = "fix-ids",
     dry_run: bool = False,
     quiet: bool = False,
     log_file: Path | None = None,


### PR DESCRIPTION
PR fixes the default value of the `mode` parameter so that it matches what's set above, and also so that it's a value that's accepted.