### PR TITLE
feat: add semantic_catalog.list_objects method

### DIFF
--- a/projects/pgai/tests/semantic_catalog/test_search.py
+++ b/projects/pgai/tests/semantic_catalog/test_search.py
@@ -58,6 +58,30 @@ async def setup_database(container: PostgresContainer) -> None:
             await cur.execute(script)  # pyright: ignore [reportArgumentType]
 
 
+async def test_list_objects(container: PostgresContainer) -> None:
+    async with await psycopg.AsyncConnection.connect(
+        container.connection_string(database=DATABASE)
+    ) as con:
+        sc = await semantic_catalog.from_name(con, "default")
+        obj_descs = await sc.list_objects(con)
+        assert len(obj_descs) > 0
+        obj_desc = obj_descs[0]
+        assert obj_desc.objnames == ["postgres_air", "airport"]
+        assert obj_desc.description is not None
+
+
+async def test_list_objects_objtype(container: PostgresContainer) -> None:
+    async with await psycopg.AsyncConnection.connect(
+        container.connection_string(database=DATABASE)
+    ) as con:
+        sc = await semantic_catalog.from_name(con, "default")
+        obj_descs = await sc.list_objects(con, objtype="table column")
+        assert len(obj_descs) > 0
+        obj_desc = obj_descs[0]
+        assert obj_desc.objnames == ["postgres_air", "airport", "airport_code"]
+        assert obj_desc.description is not None
+
+
 async def test_search_obj_sentence_transformers(container: PostgresContainer) -> None:
     async with await psycopg.AsyncConnection.connect(
         container.connection_string(database=DATABASE)


### PR DESCRIPTION
PR adds a `semantic_catalog.list_objects` method to get schema objects from the catalog. There's a `objtype` parameter to allow getting specific objects. I had contemplated adding a `objnames` parameter to allow listing more specific objects (e.g. doing `objtype='table column', objnames=['public', 'airport']` could be used to fetch all columns for a specific table, but decided against it as I wasn't sure exactly what the best API for it would be (e.g. allowing partial matching, multiple different `objnames` for it, etc.). I feel like it's easy enough to do the filtering in python for what I need, and we can expand this later as we better understand how people might use it outside of us.