### PR TITLE
chore: configure release please strategy for pre major version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
   "include-component-in-tag": true,
   "release-type": "python",
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "pull-request-header": ":robot: Release ready",
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },


### PR DESCRIPTION
We are still tagging our release according to our development phase (pre first major 1.0.0). 
Recently, we have been [forcing manually](https://github.com/timescale/pgai/commit/b885d4ffc06ed91b5eaf21a9046955799d7eb5ec) to release features without bumping the minor version but patch instead, and considering the actual minor number to be only bumped when breaking changes are introduced. 

We already had the `"bump-minor-pre-major": true,` option. This PR sets `"bump-patch-for-minor-pre-major": true,` in our release please config file so we do not have to do any [extra manual step](https://github.com/googleapis/release-please?tab=readme-ov-file#how-do-i-change-the-version-number) per default (even though we are always able to choose which to bump).

```js
  // BREAKING CHANGE only bumps semver minor if version < 1.0.0
  // absence defaults to false
  "bump-minor-pre-major": true,

  // feat commits bump semver patch instead of minor if version < 1.0.0
  // absence defaults to false
  "bump-patch-for-minor-pre-major": true,
```