### PR TITLE
chore: ignore dist directory from pyright

### DIFF
--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -95,6 +95,7 @@ exclude = [
     ".venv",
     ".direnv",
     ".devenv",
+    "dist/*",
     "db/tests/*",
 ]
 reportImplicitOverride = true


### PR DESCRIPTION
PR adds the `projects/pgai/dist` directory to the pyright ignore list. I had generated this directory doing some wheel testing, and it's annoying to require deleting it before `just type-check` would work properly.