### PR TITLE
feat: make yaml export/import idempotent

### DIFF
--- a/projects/pgai/db/sql/idempotent/014-semantic-catalog.sql
+++ b/projects/pgai/db/sql/idempotent/014-semantic-catalog.sql
@@ -1277,6 +1277,42 @@ set search_path to pg_catalog, pg_temp
 ;
 
 -------------------------------------------------------------------------------
+-- sc_update_sql_desc
+create or replace function ai.sc_update_sql_desc
+( id int8
+, sql text
+, description text
+, catalog_name name default 'default'
+)
+returns void
+as $func$
+declare
+    _catalog_name name = sc_update_sql_desc.catalog_name;
+    _sql text;
+begin
+    select format
+    ( $sql$
+        update ai.semantic_catalog_sql_%s set
+          sql = $1
+        , description = $2
+        where id = $3
+      $sql$
+    , x.id
+    ) into strict _sql
+    from ai.semantic_catalog x
+    where x.catalog_name = _catalog_name
+    ;
+    execute _sql using
+      sql
+    , description
+    , id
+    ;
+end
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;
+
+-------------------------------------------------------------------------------
 -- sc_add_fact
 create or replace function ai.sc_add_fact
 ( description text
@@ -1307,6 +1343,35 @@ begin
     execute _sql using description
     into strict _id;
     return _id;
+end
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;
+
+-------------------------------------------------------------------------------
+-- sc_update_fact
+create or replace function ai.sc_update_fact
+( id int8
+, description text
+, catalog_name name default 'default'
+)
+returns void
+as $func$
+declare
+    _catalog_name name = sc_update_fact.catalog_name;
+    _sql text;
+begin
+    select format
+    ( $sql$
+        update ai.semantic_catalog_fact_%s set description = $1
+        where id = $2
+      $sql$
+    , x.id
+    ) into strict _sql
+    from ai.semantic_catalog x
+    where x.catalog_name = _catalog_name
+    ;
+    execute _sql using description, id;
 end
 $func$ language plpgsql volatile security invoker
 set search_path to pg_catalog, pg_temp

--- a/projects/pgai/pgai/data/ai.sql
+++ b/projects/pgai/pgai/data/ai.sql
@@ -5606,6 +5606,42 @@ set search_path to pg_catalog, pg_temp
 ;
 
 -------------------------------------------------------------------------------
+-- sc_update_sql_desc
+create or replace function ai.sc_update_sql_desc
+( id int8
+, sql text
+, description text
+, catalog_name name default 'default'
+)
+returns void
+as $func$
+declare
+    _catalog_name name = sc_update_sql_desc.catalog_name;
+    _sql text;
+begin
+    select format
+    ( $sql$
+        update ai.semantic_catalog_sql_%s set
+          sql = $1
+        , description = $2
+        where id = $3
+      $sql$
+    , x.id
+    ) into strict _sql
+    from ai.semantic_catalog x
+    where x.catalog_name = _catalog_name
+    ;
+    execute _sql using
+      sql
+    , description
+    , id
+    ;
+end
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;
+
+-------------------------------------------------------------------------------
 -- sc_add_fact
 create or replace function ai.sc_add_fact
 ( description text
@@ -5636,6 +5672,35 @@ begin
     execute _sql using description
     into strict _id;
     return _id;
+end
+$func$ language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;
+
+-------------------------------------------------------------------------------
+-- sc_update_fact
+create or replace function ai.sc_update_fact
+( id int8
+, description text
+, catalog_name name default 'default'
+)
+returns void
+as $func$
+declare
+    _catalog_name name = sc_update_fact.catalog_name;
+    _sql text;
+begin
+    select format
+    ( $sql$
+        update ai.semantic_catalog_fact_%s set description = $1
+        where id = $2
+      $sql$
+    , x.id
+    ) into strict _sql
+    from ai.semantic_catalog x
+    where x.catalog_name = _catalog_name
+    ;
+    execute _sql using description, id;
 end
 $func$ language plpgsql volatile security invoker
 set search_path to pg_catalog, pg_temp

--- a/projects/pgai/tests/semantic_catalog/.gitignore
+++ b/projects/pgai/tests/semantic_catalog/.gitignore
@@ -1,2 +1,4 @@
 *.actual
 dump.expected
+data/export1.yaml
+data/export2.yaml

--- a/projects/pgai/tests/semantic_catalog/data/catalog.yaml
+++ b/projects/pgai/tests/semantic_catalog/data/catalog.yaml
@@ -247,3 +247,16 @@ description: Advances every timestamp/timestamptz column in all tables of the sp
   schema by a given number of weeks, executing or merely displaying the generated
   UPDATE statements according to the p_run flag.
 ...
+---
+type: sql_example
+sql: select f.id, f.scheduled_departure, f.scheduled_departure at time zone a.airport_tz
+  as scheduled_departure_local , a.airport_tz as departure_tz from postgres_air.flight
+  f inner join postgres_air.airport a on (f.departure_airport = a.airport_code)
+description: This query demonstrates how to compute a flight's departure time in the
+  local time of the departure airport using the airport's time zone.
+...
+---
+type: fact
+description: The names of cities in the city column of the airport table are in all
+  capital letters. e.g. "TOKYO"
+...


### PR DESCRIPTION
Facts and SQL Examples don't have a natural key. Prior to this PR, exporting a semantic catalog to a yaml file and then importing the file would result in duplicate facts/examples. This PR makes export/import idempotent by adding the ids of the Facts and SQL Examples to the yaml. If the id is present, the object is updated rather than inserted.