### PR TITLE
feat: re-export pydantic_ai exception

### DIFF
--- a/projects/pgai/pgai/semantic_catalog/exceptions.py
+++ b/projects/pgai/pgai/semantic_catalog/exceptions.py
@@ -1,0 +1,3 @@
+from pydantic_ai.exceptions import ModelHTTPError
+
+__all__ = ["ModelHTTPError"]


### PR DESCRIPTION
PR re-exports `pydantic_ai.exceptions.ModelHTTPError` to make it usable by downstream applications. This exception is raised when `agent.run` errors due to the model response endpoint not returning a 200 response (e.g. 429 response will raise this).