### PR TITLE
feat: support named vectorizers in ai.execute_vectorizer

### DIFF
--- a/projects/pgai/db/sql/idempotent/011-vectorizer-int.sql
+++ b/projects/pgai/db/sql/idempotent/011-vectorizer-int.sql
@@ -1248,3 +1248,22 @@ end
 $func$
 language plpgsql security invoker
 ;
+
+-------------------------------------------------------------------------------
+-- execute_vectorizer by vectorizer name
+create or replace function ai.execute_vectorizer(vectorizer_name pg_catalog.text) returns void
+as $func$
+declare
+    _vectorizer_id pg_catalog.int4;
+begin
+    select v.id into strict _vectorizer_id
+    from ai.vectorizer v
+    where v.name operator(pg_catalog.=) vectorizer_name;
+
+    -- execute the vectorizer
+    perform ai.execute_vectorizer(_vectorizer_id);
+end
+$func$
+language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;

--- a/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
+++ b/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
@@ -1,3 +1,5 @@
+import os
+
 import psycopg
 import pytest
 from psycopg.rows import namedtuple_row
@@ -9,18 +11,7 @@ def db_url(user: str) -> str:
     return f"postgres://{user}@127.0.0.1:5432/test"
 
 
-def test_named_vectorizer():
-    with psycopg.connect(
-        db_url("postgres"), autocommit=True, row_factory=namedtuple_row
-    ) as con:
-        with con.cursor() as cur:
-            cur.execute("create extension if not exists timescaledb")
-            cur.execute("select to_regrole('bob') is null")
-            if cur.fetchone()[0] is True:
-                cur.execute("create user bob")
-            cur.execute("select to_regrole('adelaide') is null")
-            if cur.fetchone()[0] is True:
-                cur.execute("create user adelaide")
+def setup_website_blog_table():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
     ) as con:
@@ -35,14 +26,9 @@ def test_named_vectorizer():
                 , title text not null
                 , published timestamptz
                 , body text not null
-                , drop_me text
                 , primary key (title, published)
                 )
             """)
-            cur.execute(
-                """grant select, insert, update, delete on website.blog to bob, adelaide"""
-            )
-            cur.execute("""grant usage on schema website to adelaide""")
             cur.execute("""
                 insert into website.blog(title, published, body)
                 values
@@ -51,9 +37,50 @@ def test_named_vectorizer():
                 , ('how to make stir fry', '2022-01-06'::timestamptz, 'pick up the phone and order takeout')
             """)
 
-            # drop the drop_me column
-            cur.execute("alter table website.blog drop column drop_me")
 
+@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+def test_named_vectorizer_timescaledb():
+    setup_website_blog_table()
+    with psycopg.connect(
+        db_url("test"), autocommit=True, row_factory=namedtuple_row
+    ) as con:
+        con.add_notice_handler(detailed_notice_handler)
+        with con.cursor() as cur:
+            # create a vectorizer for the blog table
+            # language=PostgreSQL
+            cur.execute("""
+                select ai.create_vectorizer
+                ( 'website.blog'::regclass
+                , name => 'blog_vectorizer'
+                , loading=>ai.loading_column('body')
+                , embedding=>ai.embedding_openai('text-embedding-3-small', 768)
+                , formatting=>ai.formatting_python_template('title: $title published: $published $chunk')
+                , scheduling=>ai.scheduling_none()
+                , destination=>ai.destination_column('embedding1')
+                , chunking=>ai.chunking_none()
+                );
+                """)
+
+            cur.execute("create extension ai cascade")
+            cur.execute(
+                "select set_config('ai.external_functions_executor_url', 'http://0.0.0.0:8000', false)"
+            )
+            cur.execute(
+                "select set_config('ai.external_functions_executor_events_path', '/api/v1/events', false)"
+            )
+            cur.execute("select ai.execute_vectorizer('blog_vectorizer')")
+
+            with pytest.raises(psycopg.errors.NoDataFound):
+                cur.execute("select ai.execute_vectorizer('non_existent_vectorizer')")
+
+
+def test_named_vectorizer():
+    setup_website_blog_table()
+    with psycopg.connect(
+        db_url("test"), autocommit=True, row_factory=namedtuple_row
+    ) as con:
+        con.add_notice_handler(detailed_notice_handler)
+        with con.cursor() as cur:
             # create a vectorizer for the blog table
             # language=PostgreSQL
             cur.execute("""

--- a/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
+++ b/projects/pgai/db/tests/vectorizer/test_named_vectorizer.py
@@ -38,7 +38,9 @@ def setup_website_blog_table():
             """)
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_named_vectorizer_timescaledb():
     setup_website_blog_table()
     with psycopg.connect(

--- a/projects/pgai/db/tests/vectorizer/test_trigger.py
+++ b/projects/pgai/db/tests/vectorizer/test_trigger.py
@@ -11,7 +11,9 @@ def db_url(user: str) -> str:
     return f"postgres://{user}@127.0.0.1:5432/test"
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_same_table_vectorizer_timescaledb():
     with psycopg.connect(
         db_url("postgres"), autocommit=True, row_factory=namedtuple_row

--- a/projects/pgai/db/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/db/tests/vectorizer/test_vectorizer.py
@@ -201,7 +201,9 @@ def psql_cmd(cmd: str) -> str:
     return str(proc.stdout).strip()
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_vectorizer_timescaledb():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:
@@ -600,7 +602,9 @@ def test_vectorizer_timescaledb():
     assert actual == VIEW
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_drop_vectorizer():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -742,7 +746,9 @@ def test_drop_vectorizer():
             assert actual == 0
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_drop_all_vectorizer():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -1303,7 +1309,9 @@ def index_creation_tester(cur: psycopg.Cursor, vectorizer_id: int) -> None:
     assert actual is True
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_diskann_index():
     # pgvectorscale must be installed by a superuser
     with psycopg.connect(
@@ -1356,7 +1364,9 @@ def test_diskann_index():
             index_creation_tester(cur, vectorizer_id)
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_hnsw_index():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -1403,7 +1413,9 @@ def test_hnsw_index():
             index_creation_tester(cur, vectorizer_id)
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_index_create_concurrency():
     # pgvectorscale must be installed by a superuser
     with psycopg.connect(
@@ -2254,7 +2266,9 @@ def test_weird_primary_key():
             assert actual == 7
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_install_ai_extension_before_library():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:
@@ -2266,7 +2280,9 @@ def test_install_ai_extension_before_library():
     pgai.install(db_url("test"))
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_install_library_before_ai_extension():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:

--- a/projects/pgai/pgai/data/ai.sql
+++ b/projects/pgai/pgai/data/ai.sql
@@ -3516,6 +3516,24 @@ $func$
 language plpgsql security invoker
 ;
 
+-------------------------------------------------------------------------------
+-- execute_vectorizer by vectorizer name
+create or replace function ai.execute_vectorizer(vectorizer_name pg_catalog.text) returns void
+as $func$
+declare
+    _vectorizer_id pg_catalog.int4;
+begin
+    select v.id into strict _vectorizer_id
+    from ai.vectorizer v
+    where v.name operator(pg_catalog.=) vectorizer_name;
+
+    -- execute the vectorizer
+    perform ai.execute_vectorizer(_vectorizer_id);
+end
+$func$
+language plpgsql volatile security invoker
+set search_path to pg_catalog, pg_temp
+;
 
 --------------------------------------------------------------------------------
 -- 012-vectorizer-api.sql


### PR DESCRIPTION
This PR adds a new signature for the `ai.execute_vectorizer` function that accepts a vectorizer name as input instead of an id. 