### PR TITLE
fix: incorrect error of column does not exist

### DIFF
--- a/projects/pgai/db/sql/idempotent/008-loading.sql
+++ b/projects/pgai/db/sql/idempotent/008-loading.sql
@@ -67,7 +67,7 @@ end if;
      if _column_name is null then
         raise exception 'invalid loading config, missing column_name';
 end if;
-    
+
     if (config operator(pg_catalog.->>) 'retries') is null or (config operator(pg_catalog.->>) 'retries')::int < 0 then
         raise exception 'invalid loading config, retries must be a non-negative integer';
 end if;
@@ -84,11 +84,14 @@ end if;
         and k.relname operator(pg_catalog.=) source_table
         and a.attnum operator(pg_catalog.>) 0
         and a.attname operator(pg_catalog.=) _column_name
-        and y.typname in ('text', 'varchar', 'char', 'bpchar', 'bytea')
         and not a.attisdropped;
 
     if _column_type is null then
             raise exception 'column_name in config does not exist in the table: %', _column_name;
+    end if;
+
+    if _column_type not in ('text', 'varchar', 'char', 'bpchar', 'bytea') then
+            raise exception 'column_name % in config is of invalid type %. Supported types are: text, varchar, char, bpchar, bytea', _column_name, _column_type;
     end if;
 
     if _implementation = 'uri' and _column_type not in ('text', 'varchar', 'char', 'bpchar') then

--- a/projects/pgai/db/tests/vectorizer/test_vectorizer.py
+++ b/projects/pgai/db/tests/vectorizer/test_vectorizer.py
@@ -201,7 +201,9 @@ def psql_cmd(cmd: str) -> str:
     return str(proc.stdout).strip()
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_vectorizer_timescaledb():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:
@@ -600,7 +602,9 @@ def test_vectorizer_timescaledb():
     assert actual == VIEW
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_drop_vectorizer():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -742,7 +746,9 @@ def test_drop_vectorizer():
             assert actual == 0
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_drop_all_vectorizer():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -1303,7 +1309,9 @@ def index_creation_tester(cur: psycopg.Cursor, vectorizer_id: int) -> None:
     assert actual is True
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_diskann_index():
     # pgvectorscale must be installed by a superuser
     with psycopg.connect(
@@ -1356,7 +1364,9 @@ def test_diskann_index():
             index_creation_tester(cur, vectorizer_id)
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_hnsw_index():
     with psycopg.connect(
         db_url("test"), autocommit=True, row_factory=namedtuple_row
@@ -1403,7 +1413,9 @@ def test_hnsw_index():
             index_creation_tester(cur, vectorizer_id)
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_index_create_concurrency():
     # pgvectorscale must be installed by a superuser
     with psycopg.connect(
@@ -2254,7 +2266,9 @@ def test_weird_primary_key():
             assert actual == 7
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_install_ai_extension_before_library():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:
@@ -2266,7 +2280,9 @@ def test_install_ai_extension_before_library():
     pgai.install(db_url("test"))
 
 
-@pytest.mark.skipif(os.getenv("PG_MAJOR") == "15", reason="does not support pg15")
+@pytest.mark.skipif(
+    os.getenv("PG_MAJOR") == "15", reason="extension does not support pg15"
+)
 def test_install_library_before_ai_extension():
     with psycopg.connect(db_url("test")) as con:
         with con.cursor() as cur:

--- a/projects/pgai/pgai/data/ai.sql
+++ b/projects/pgai/pgai/data/ai.sql
@@ -1974,7 +1974,7 @@ end if;
      if _column_name is null then
         raise exception 'invalid loading config, missing column_name';
 end if;
-    
+
     if (config operator(pg_catalog.->>) 'retries') is null or (config operator(pg_catalog.->>) 'retries')::int < 0 then
         raise exception 'invalid loading config, retries must be a non-negative integer';
 end if;
@@ -1991,11 +1991,14 @@ end if;
         and k.relname operator(pg_catalog.=) source_table
         and a.attnum operator(pg_catalog.>) 0
         and a.attname operator(pg_catalog.=) _column_name
-        and y.typname in ('text', 'varchar', 'char', 'bpchar', 'bytea')
         and not a.attisdropped;
 
     if _column_type is null then
             raise exception 'column_name in config does not exist in the table: %', _column_name;
+    end if;
+
+    if _column_type not in ('text', 'varchar', 'char', 'bpchar', 'bytea') then
+            raise exception 'column_name % in config is of invalid type %. Supported types are: text, varchar, char, bpchar, bytea', _column_name, _column_type;
     end if;
 
     if _implementation = 'uri' and _column_type not in ('text', 'varchar', 'char', 'bpchar') then


### PR DESCRIPTION
If the loading column had a unsupported type the error message that was being shown was related to the column not existing. Now an invalid type error messages is shown with the supported types.