### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directories:
       - "projects/pgai"
+      - "projects/extension"
+      - "examples/discord_bot"
     schedule:
       interval: "monthly"
     commit-message:
@@ -17,7 +19,10 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "projects/pgai"
+      - "projects/extension"
+      - "examples/discord_bot"
     schedule:
       interval: "monthly"
     commit-message:


### PR DESCRIPTION
Switches "package ecosystem" from "pip" to "uv" and adds some directories which contain dependencies.

Note: it seems as though dependabot's uv integration is currently spotty, but this should also bump the version in generated lockfiles.