### PR TITLE
chore: use org automation token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
 
   release-pypi:
     name: Publish to PyPi


### PR DESCRIPTION
When release-please runs with the `GITHUB_TOKEN` token, workflow actions are not run on PRs that it creates due to GitHub's restrictions [1]:

> When you use the repository's GITHUB_TOKEN to perform tasks,
> events triggered by the GITHUB_TOKEN, with the exception of
> workflow_dispatch and repository_dispatch, will not create a
> new workflow run.

Switch to using the timescale-automation token.

[1]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow