### PR TITLE
ci: add compilers for arm64 docker images required for pandas package

### DIFF
--- a/projects/pgai/Dockerfile
+++ b/projects/pgai/Dockerfile
@@ -8,6 +8,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock ./
 
+RUN set -e; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends build-essential
+
 RUN uv sync --frozen --no-install-project --no-dev
 
 # Note: some dependencies are not supported on 3.13, do not bump until that is sorted out


### PR DESCRIPTION
Fixes https://github.com/timescale/pgai/actions/runs/15590246552/job/43907222334