### PR TITLE
chore: store golden query results in files

### DIFF
--- a/projects/pgai/db/justfile
+++ b/projects/pgai/db/justfile
@@ -1,6 +1,7 @@
 export PROJECT_JUSTFILE := "1" # Note: used in build.py
 PG_MAJOR := env("PG_MAJOR", "17")
 PG_BIN := env("PG_BIN", "/usr/lib/postgresql/" + PG_MAJOR + "/bin")
+OVERWRITE_GOLDEN := env("OVERWRITE_GOLDEN", "false")
 
 # Show list of recipes
 default:
@@ -14,7 +15,7 @@ ci: docker-build docker-run docker-sync
   docker exec pgai-db just build
   docker exec pgai-db just lint
   docker exec -d pgai-db just test-server
-  docker exec pgai-db just test
+  docker exec -e OVERWRITE_GOLDEN={{OVERWRITE_GOLDEN}} pgai-db just test
 
 clean:
 	@./build.py clean
@@ -30,7 +31,7 @@ test-server:
 
 test:
 	@./build.py test
-	
+
 lint:
 	@./build.py lint
 

--- a/projects/pgai/db/tests/golden/queue-table-16.expected
+++ b/projects/pgai/db/tests/golden/queue-table-16.expected
@@ -1,0 +1,11 @@
+Table "ai._vectorizer_q_1"
+       Column        |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ title               | text                     |           | not null |         | extended |             |              | 
+ published           | timestamp with time zone |           | not null |         | plain    |             |              | 
+ queued_at           | timestamp with time zone |           | not null | now()   | plain    |             |              | 
+ loading_retries     | integer                  |           | not null | 0       | plain    |             |              | 
+ loading_retry_after | timestamp with time zone |           |          |         | plain    |             |              | 
+Indexes:
+    "_vectorizer_q_1_title_published_idx" btree (title, published)
+Access method: heap

--- a/projects/pgai/db/tests/golden/queue-table-17.expected
+++ b/projects/pgai/db/tests/golden/queue-table-17.expected
@@ -1,0 +1,11 @@
+Table "ai._vectorizer_q_1"
+       Column        |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description 
+---------------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
+ title               | text                     |           | not null |         | extended |             |              | 
+ published           | timestamp with time zone |           | not null |         | plain    |             |              | 
+ queued_at           | timestamp with time zone |           | not null | now()   | plain    |             |              | 
+ loading_retries     | integer                  |           | not null | 0       | plain    |             |              | 
+ loading_retry_after | timestamp with time zone |           |          |         | plain    |             |              | 
+Indexes:
+    "_vectorizer_q_1_title_published_idx" btree (title, published)
+Access method: heap

--- a/projects/pgai/db/tests/golden/source-table-16.expected
+++ b/projects/pgai/db/tests/golden/source-table-16.expected
@@ -1,0 +1,13 @@
+Table "website.blog"
+  Column   |           Type           | Collation | Nullable |           Default            | Storage  | Compression | Stats target | Description 
+-----------+--------------------------+-----------+----------+------------------------------+----------+-------------+--------------+-------------
+ id        | integer                  |           | not null | generated always as identity | plain    |             |              | 
+ title     | text                     |           | not null |                              | extended |             |              | 
+ published | timestamp with time zone |           | not null |                              | plain    |             |              | 
+ body      | text                     |           | not null |                              | extended |             |              | 
+Indexes:
+    "blog_pkey" PRIMARY KEY, btree (title, published)
+Triggers:
+    _vectorizer_src_trg_1 AFTER INSERT OR DELETE OR UPDATE ON website.blog FOR EACH ROW EXECUTE FUNCTION ai._vectorizer_src_trg_1()
+    _vectorizer_src_trg_1_truncate AFTER TRUNCATE ON website.blog FOR EACH STATEMENT EXECUTE FUNCTION ai._vectorizer_src_trg_1()
+Access method: heap

--- a/projects/pgai/db/tests/golden/source-table-17.expected
+++ b/projects/pgai/db/tests/golden/source-table-17.expected
@@ -1,0 +1,13 @@
+Table "website.blog"
+  Column   |           Type           | Collation | Nullable |           Default            | Storage  | Compression | Stats target | Description 
+-----------+--------------------------+-----------+----------+------------------------------+----------+-------------+--------------+-------------
+ id        | integer                  |           | not null | generated always as identity | plain    |             |              | 
+ title     | text                     |           | not null |                              | extended |             |              | 
+ published | timestamp with time zone |           | not null |                              | plain    |             |              | 
+ body      | text                     |           | not null |                              | extended |             |              | 
+Indexes:
+    "blog_pkey" PRIMARY KEY, btree (title, published)
+Triggers:
+    _vectorizer_src_trg_1 AFTER INSERT OR DELETE OR UPDATE ON website.blog FOR EACH ROW EXECUTE FUNCTION ai._vectorizer_src_trg_1()
+    _vectorizer_src_trg_1_truncate AFTER TRUNCATE ON website.blog FOR EACH STATEMENT EXECUTE FUNCTION ai._vectorizer_src_trg_1()
+Access method: heap

--- a/projects/pgai/db/tests/golden/source-trigger-16.expected
+++ b/projects/pgai/db/tests/golden/source-trigger-16.expected
@@ -1,0 +1,5 @@
+List of functions
+ Schema |         Name          | Result data type | Argument data types | Type | Volatility | Parallel | Owner | Security | Access privileges | Language | Internal name | Description 
+--------+-----------------------+------------------+---------------------+------+------------+----------+-------+----------+-------------------+----------+---------------+-------------
+ ai     | _vectorizer_src_trg_1 | trigger          |                     | func | volatile   | safe     | test  | definer  | test=X/test       | plpgsql  |               | 
+(1 row)

--- a/projects/pgai/db/tests/golden/source-trigger-17.expected
+++ b/projects/pgai/db/tests/golden/source-trigger-17.expected
@@ -1,0 +1,5 @@
+List of functions
+ Schema |         Name          | Result data type | Argument data types | Type | Volatility | Parallel | Owner | Security | Access privileges | Language | Internal name | Description 
+--------+-----------------------+------------------+---------------------+------+------------+----------+-------+----------+-------------------+----------+---------------+-------------
+ ai     | _vectorizer_src_trg_1 | trigger          |                     | func | volatile   | safe     | test  | definer  | test=X/test       | plpgsql  |               | 
+(1 row)

--- a/projects/pgai/db/tests/golden/target-table-16.expected
+++ b/projects/pgai/db/tests/golden/target-table-16.expected
@@ -1,0 +1,13 @@
+Table "website.blog_embedding_store"
+     Column     |           Type           | Collation | Nullable |      Default      | Storage  | Compression | Stats target | Description 
+----------------+--------------------------+-----------+----------+-------------------+----------+-------------+--------------+-------------
+ embedding_uuid | uuid                     |           | not null | gen_random_uuid() | plain    |             |              | 
+ title          | text                     |           | not null |                   | extended |             |              | 
+ published      | timestamp with time zone |           | not null |                   | plain    |             |              | 
+ chunk_seq      | integer                  |           | not null |                   | plain    |             |              | 
+ chunk          | text                     |           | not null |                   | extended |             |              | 
+ embedding      | vector(768)              |           | not null |                   | main     |             |              | 
+Indexes:
+    "blog_embedding_store_pkey" PRIMARY KEY, btree (embedding_uuid)
+    "blog_embedding_store_title_published_chunk_seq_key" UNIQUE CONSTRAINT, btree (title, published, chunk_seq)
+Access method: heap

--- a/projects/pgai/db/tests/golden/target-table-17.expected
+++ b/projects/pgai/db/tests/golden/target-table-17.expected
@@ -1,0 +1,13 @@
+Table "website.blog_embedding_store"
+     Column     |           Type           | Collation | Nullable |      Default      | Storage  | Compression | Stats target | Description 
+----------------+--------------------------+-----------+----------+-------------------+----------+-------------+--------------+-------------
+ embedding_uuid | uuid                     |           | not null | gen_random_uuid() | plain    |             |              | 
+ title          | text                     |           | not null |                   | extended |             |              | 
+ published      | timestamp with time zone |           | not null |                   | plain    |             |              | 
+ chunk_seq      | integer                  |           | not null |                   | plain    |             |              | 
+ chunk          | text                     |           | not null |                   | extended |             |              | 
+ embedding      | vector(768)              |           | not null |                   | main     |             |              | 
+Indexes:
+    "blog_embedding_store_pkey" PRIMARY KEY, btree (embedding_uuid)
+    "blog_embedding_store_title_published_chunk_seq_key" UNIQUE CONSTRAINT, btree (title, published, chunk_seq)
+Access method: heap

--- a/projects/pgai/db/tests/golden/view-16.expected
+++ b/projects/pgai/db/tests/golden/view-16.expected
@@ -1,0 +1,22 @@
+View "website.blog_embedding"
+     Column     |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------------+--------------------------+-----------+----------+---------+----------+-------------
+ embedding_uuid | uuid                     |           |          |         | plain    | 
+ chunk_seq      | integer                  |           |          |         | plain    | 
+ chunk          | text                     |           |          |         | extended | 
+ embedding      | vector(768)              |           |          |         | external | 
+ id             | integer                  |           |          |         | plain    | 
+ title          | text                     |           |          |         | extended | 
+ published      | timestamp with time zone |           |          |         | plain    | 
+ body           | text                     |           |          |         | extended | 
+View definition:
+ SELECT t.embedding_uuid,
+    t.chunk_seq,
+    t.chunk,
+    t.embedding,
+    s.id,
+    t.title,
+    t.published,
+    s.body
+   FROM website.blog_embedding_store t
+     LEFT JOIN website.blog s ON t.title = s.title AND t.published = s.published;

--- a/projects/pgai/db/tests/golden/view-17.expected
+++ b/projects/pgai/db/tests/golden/view-17.expected
@@ -1,0 +1,22 @@
+View "website.blog_embedding"
+     Column     |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------------+--------------------------+-----------+----------+---------+----------+-------------
+ embedding_uuid | uuid                     |           |          |         | plain    | 
+ chunk_seq      | integer                  |           |          |         | plain    | 
+ chunk          | text                     |           |          |         | extended | 
+ embedding      | vector(768)              |           |          |         | external | 
+ id             | integer                  |           |          |         | plain    | 
+ title          | text                     |           |          |         | extended | 
+ published      | timestamp with time zone |           |          |         | plain    | 
+ body           | text                     |           |          |         | extended | 
+View definition:
+ SELECT t.embedding_uuid,
+    t.chunk_seq,
+    t.chunk,
+    t.embedding,
+    s.id,
+    t.title,
+    t.published,
+    s.body
+   FROM website.blog_embedding_store t
+     LEFT JOIN website.blog s ON t.title = s.title AND t.published = s.published;


### PR DESCRIPTION
Moves the "golden query" results from being inline in the code to being in separate files, and introduces a workflow to overwrite the files, namely:

OVERWRITE_GOLDEN=true just ci

This makes it easier to maintain these golden tests when things change.