### PR TITLE
chore: ignore line-too-long (E501) lint

### DIFF
--- a/projects/pgai/pgai/_install/install.py
+++ b/projects/pgai/pgai/_install/install.py
@@ -59,7 +59,7 @@ def raise_on_old_extension_version(result: Any | None) -> None:
 
     if semver.VersionInfo.parse(result[0]) < semver.VersionInfo.parse("0.10.0"):
         raise Exception(
-            f"The ai extension is outdated and must be upgraded. Installed version: {result[0]}, required version: 0.10.0"  # noqa: E501
+            f"The ai extension is outdated and must be upgraded. Installed version: {result[0]}, required version: 0.10.0"
         )
 
 
@@ -108,7 +108,7 @@ async def ainstall(
         pg_version = int(result[0]) if result is not None else None
         if pg_version and pg_version < 15:
             raise RuntimeError(
-                f"postgres {pg_version} is unsupported, pgai requires postgres version 15 or greater"  # noqa
+                f"postgres {pg_version} is unsupported, pgai requires postgres version 15 or greater"
             )
 
         if vector_extension_schema is None:
@@ -176,7 +176,7 @@ def install(
         pg_version = int(result[0]) if result is not None else None
         if pg_version and pg_version < 15:
             raise RuntimeError(
-                f"postgres {pg_version} is unsupported, pgai requires postgres version 15 or greater"  # noqa
+                f"postgres {pg_version} is unsupported, pgai requires postgres version 15 or greater"
             )
 
         if vector_extension_schema is None:

--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -112,7 +112,7 @@ def download_models():
     "vectorizer_ids",
     type=click.INT,
     multiple=True,
-    help="Only fetch work from the given vectorizer ids. If not provided, all vectorizers will be fetched.",  # noqa
+    help="Only fetch work from the given vectorizer ids. If not provided, all vectorizers will be fetched.",
     default=[],
 )
 @click.option(
@@ -130,7 +130,6 @@ def download_models():
     help="The interval, in duration string or integer (seconds), "
     "to wait before checking for new work after processing "
     "all available work in the queue.",
-    # noqa
 )
 @click.option(
     "--once",
@@ -239,7 +238,7 @@ cli.add_command(vectorizer)
     is_flag=True,
     default=False,
     show_default=True,
-    help="Raise an error when the extension already exists and is at the latest version.",  # noqa: E501
+    help="Raise an error when the extension already exists and is at the latest version.",
 )
 def install(db_url: str, strict: bool) -> None:
     import pgai
@@ -508,7 +507,7 @@ def describe(
     "--embed-config",
     type=click.STRING,
     default=None,
-    help="Name of the embedding configuration to use. If not specified, uses all available configurations.",  # noqa: E501
+    help="Name of the embedding configuration to use. If not specified, uses all available configurations.",
 )
 @click.option(
     "-b",
@@ -658,7 +657,7 @@ def vectorize(
     "--embed-config",
     type=click.STRING,
     default=None,
-    help="The name of the embedding configuration to generate embeddings for. (If None, do all)",  # noqa: E501
+    help="The name of the embedding configuration to generate embeddings for. (If None, do all)",
 )
 @click.option(
     "--base-url",
@@ -670,7 +669,7 @@ def vectorize(
     "--api-key-name",
     type=click.STRING,
     default=None,
-    help="The name of the environment variable containing the API key for the embedding provider",  # noqa: E501
+    help="The name of the environment variable containing the API key for the embedding provider",
 )
 @click.option(
     "-q",
@@ -737,7 +736,7 @@ def create(
         \b
         # Create a catalog with custom embedding name
         pgai semantic-catalog create --catalog-name my_catalog --embed-config custom_embeddings
-    """  # noqa: E501
+    """
     import logging
 
     log_handlers: list[logging.Handler] = []
@@ -832,7 +831,7 @@ def create(
     "--embed-config",
     type=click.STRING,
     default=None,
-    help="The name of the embedding configuration to generate embeddings for. (If None, do all)",  # noqa: E501
+    help="The name of the embedding configuration to generate embeddings for. (If None, do all)",
 )
 @click.option(
     "-b",
@@ -894,7 +893,7 @@ def import_catalog(
         \b
         # Import from stdin
         cat descriptions.yaml | pgai semantic-catalog import
-    """  # noqa: E501
+    """
     import logging
 
     log_handlers: list[logging.Handler] = []
@@ -973,7 +972,7 @@ def import_catalog(
     "--catalog-name",
     type=click.STRING,
     default="default",
-    help="The name of the semantic catalog to generate embeddings for.",  # noqa: E501
+    help="The name of the semantic catalog to generate embeddings for.",
 )
 @click.option(
     "-q",
@@ -1024,7 +1023,7 @@ def export_catalog(
         \b
         # Export to stdout
         pgai semantic-catalog export | tee catalog_backup.yaml
-    """  # noqa: E501
+    """
     import logging
 
     log_handlers: list[logging.Handler] = []
@@ -1113,14 +1112,14 @@ def export_catalog(
     "--embed-config",
     type=click.STRING,
     default=None,
-    help="Name of the embedding configuration to use. If not specified, uses the first available configuration.",  # noqa: E501
+    help="Name of the embedding configuration to use. If not specified, uses the first available configuration.",
 )
 @click.option(
     "-p",
     "--prompt",
     type=click.STRING,
     default=None,
-    help="Natural language description of the SQL query you want to generate (e.g., 'Find all orders placed last month')",  # noqa: E501
+    help="Natural language description of the SQL query you want to generate (e.g., 'Find all orders placed last month')",
     required=True,
 )
 @click.option(
@@ -1239,7 +1238,7 @@ def generate_sql(
         # Save the final prompt for debugging
         pgai semantic-catalog generate-sql --prompt "Find inactive customers" \\
             --save-final-prompt debug_prompt.txt
-    """  # noqa: E501
+    """
     import logging
 
     log_handlers: list[logging.Handler] = []
@@ -1332,15 +1331,15 @@ def generate_sql(
         table.add_row("Requests", str(usage.requests))
         table.add_row(
             "Request Tokens",
-            str(usage.request_tokens) if usage.request_tokens else "?",  # noqa: E501
+            str(usage.request_tokens) if usage.request_tokens else "?",
         )
         table.add_row(
             "Response Tokens",
-            str(usage.response_tokens) if usage.response_tokens else "?",  # noqa
+            str(usage.response_tokens) if usage.response_tokens else "?",
         )
         table.add_row(
             "Total Tokens",
-            str(usage.total_tokens) if usage.total_tokens else "?",  # noqa: E501
+            str(usage.total_tokens) if usage.total_tokens else "?",
         )
         console.print(table)
 
@@ -1385,7 +1384,7 @@ def generate_sql(
     "--prompt",
     type=click.STRING,
     default=None,
-    help="Natural language query to search for related database objects (e.g., 'customer orders')",  # noqa: E501
+    help="Natural language query to search for related database objects (e.g., 'customer orders')",
     required=True,
 )
 @click.option(

--- a/projects/pgai/pgai/semantic_catalog/describe.py
+++ b/projects/pgai/pgai/semantic_catalog/describe.py
@@ -4,7 +4,7 @@ This module provides functionality for finding database objects (tables, views, 
 and generating natural language descriptions for them using AI models. These descriptions
 can be used to populate a semantic catalog, making it easier for users to understand
 the database schema and its purpose.
-"""  # noqa: E501
+"""
 
 import logging
 from collections.abc import Callable
@@ -55,7 +55,7 @@ async def find_tables(
 
     Returns:
         A list of PostgreSQL object IDs (OIDs) for the matching tables.
-    """  # noqa: E501
+    """
     async with con.cursor() as cur:
         filters: list[Composable] = []
         params: dict[str, Any] = {}
@@ -128,7 +128,7 @@ async def find_views(
 
     Returns:
         A list of PostgreSQL object IDs (OIDs) for the matching views.
-    """  # noqa: E501
+    """
     async with con.cursor() as cur:
         filters: list[Composable] = []
         params: dict[str, Any] = {}
@@ -201,7 +201,7 @@ async def find_procedures(
 
     Returns:
         A list of PostgreSQL object IDs (OIDs) for the matching procedures and functions.
-    """  # noqa: E501
+    """
     async with con.cursor() as cur:
         filters: list[Composable] = []
         params: dict[str, Any] = {}
@@ -282,7 +282,7 @@ async def generate_table_descriptions(
 
     Returns:
         Updated Usage object with information about token usage.
-    """  # noqa: E501
+    """
 
     def batches(batch_size: int):
         for i in range(0, len(oids), batch_size):
@@ -305,28 +305,25 @@ async def generate_table_descriptions(
                 description="",
                 columns=[
                     file.Column(name=c.name, description="")
-                    for c in (table.columns or [])  # noqa: E501
+                    for c in (table.columns or [])
                 ],
             )
         logger.debug(f"rendering details for batch of {len(batch)} tables")
         rendered: str = render.render_tables(tables)
         prompt = (
-            (
-                "Below are representations of one or more PostgreSQL tables. "
-                "Generate a natural language description for each table and column represented. "  # noqa: E501
-                "Use tools to record your description. Respond ONLY with 'done' when finished. "  # noqa: E501
-                "\n\n"
-            )
-            + rendered
-        )
+            "Below are representations of one or more PostgreSQL tables. "
+            "Generate a natural language description for each table and column represented. "
+            "Use tools to record your description. Respond ONLY with 'done' when finished. "
+            "\n\n"
+        ) + rendered
 
         agent = Agent(
             model,
             model_settings=model_settings,
             name="table-describer",
             system_prompt=(
-                "You are a SQL expert who generates natural language descriptions of tables in a PostgreSQL database. "  # noqa: E501
-                "The descriptions that you generate should be a concise, single sentence."  # noqa: E501
+                "You are a SQL expert who generates natural language descriptions of tables in a PostgreSQL database. "
+                "The descriptions that you generate should be a concise, single sentence."
             ),
         )
 
@@ -344,7 +341,7 @@ async def generate_table_descriptions(
                 logger.warning(f"invalid table id provided by LLM: {table_id}")
                 return
             logger.debug(
-                f"recording description for table {table.schema_name}.{table.name}"  # noqa: E501
+                f"recording description for table {table.schema_name}.{table.name}"
             )
             table.description = description
             if progress_callback:
@@ -366,22 +363,22 @@ async def generate_table_descriptions(
             if table is None:
                 logger.warning(
                     f"invalid table id provided by LLM: {table_id} {column_name}"
-                )  # noqa: E501
+                )
                 return
             if not table.columns:
                 logger.warning(
-                    f"column described by LLM but table has no columns: {table_id} {column_name}"  # noqa: E501
+                    f"column described by LLM but table has no columns: {table_id} {column_name}"
                 )
                 return
             column = next((c for c in table.columns if c.name == column_name), None)
             if column is None:
                 logger.warning(
                     f"invalid column provided by LLM: {table_id} {column_name}"
-                )  # noqa: E501
+                )
                 return
             column.description = description
             logger.debug(
-                f"recording description for column {table.schema_name}.{table.name}.{column.name}"  # noqa
+                f"recording description for column {table.schema_name}.{table.name}.{column.name}"
             )
             if progress_callback:
                 progress_callback(
@@ -432,7 +429,7 @@ async def generate_view_descriptions(
 
     Returns:
         Updated Usage object with information about token usage.
-    """  # noqa: E501
+    """
 
     def batches(batch_size: int):
         for i in range(0, len(oids), batch_size):
@@ -453,29 +450,26 @@ async def generate_view_descriptions(
                 description="",
                 columns=[
                     file.Column(name=c.name, description="")
-                    for c in (view.columns or [])  # noqa: E501
+                    for c in (view.columns or [])
                 ],
             )
 
         logger.debug(f"rendering details for batch of {len(batch)} views")
         rendered: str = render.render_views(views)
         prompt = (
-            (
-                "Below are representations of one or more PostgreSQL views. "
-                "Generate a natural language description for each view and column represented. "  # noqa: E501
-                "Use tools to record your description. Respond ONLY with 'done' when finished. "  # noqa: E501
-                "\n\n"
-            )
-            + rendered
-        )
+            "Below are representations of one or more PostgreSQL views. "
+            "Generate a natural language description for each view and column represented. "
+            "Use tools to record your description. Respond ONLY with 'done' when finished. "
+            "\n\n"
+        ) + rendered
 
         agent = Agent(
             model,
             model_settings=model_settings,
             name="view-describer",
             system_prompt=(
-                "You are a SQL expert who generates natural language descriptions of views in a PostgreSQL database. "  # noqa: E501
-                "The descriptions that you generate should be a concise, single sentence."  # noqa: E501
+                "You are a SQL expert who generates natural language descriptions of views in a PostgreSQL database. "
+                "The descriptions that you generate should be a concise, single sentence."
             ),
         )
 
@@ -519,7 +513,7 @@ async def generate_view_descriptions(
                 return
             if not view.columns:
                 logger.warning(
-                    f"column description provided for view but view has no columns: {view_id} {column_name}"  # noqa
+                    f"column description provided for view but view has no columns: {view_id} {column_name}"
                 )
                 return
             column = next((c for c in view.columns if c.name == column_name), None)
@@ -530,7 +524,7 @@ async def generate_view_descriptions(
                 return
             column.description = description
             logger.debug(
-                f"recording description for view column {view.schema_name}.{view.name}.{column.name}"  # noqa
+                f"recording description for view column {view.schema_name}.{view.name}.{column.name}"
             )
             if progress_callback:
                 progress_callback(".".join([view.schema_name, view.name, column.name]))
@@ -577,7 +571,7 @@ async def generate_procedure_descriptions(
 
     Returns:
         Updated Usage object with information about token usage.
-    """  # noqa: E501
+    """
 
     def batches(batch_size: int):
         for i in range(0, len(oids), batch_size):
@@ -618,22 +612,19 @@ async def generate_procedure_descriptions(
         logger.debug(f"rendering details for batch of {len(batch)} procedures")
         rendered: str = render.render_procedures(procs)
         prompt = (
-            (
-                "Below are representations of one or more PostgreSQL procedures/functions. "  # noqa
-                "Generate a natural language description for each procedure/function represented. "  # noqa
-                "Use the tool to record your description. Respond ONLY with 'done' when finished. "  # noqa
-                "\n\n"
-            )
-            + rendered
-        )
+            "Below are representations of one or more PostgreSQL procedures/functions. "
+            "Generate a natural language description for each procedure/function represented. "
+            "Use the tool to record your description. Respond ONLY with 'done' when finished. "
+            "\n\n"
+        ) + rendered
 
         agent = Agent(
             model,
             model_settings=model_settings,
             name="procedure-describer",
             system_prompt=(
-                "You are a SQL expert who generates natural language descriptions of procedures and functions in a PostgreSQL database. "  # noqa: E501
-                "The descriptions that you generate should be a concise, single sentence."  # noqa: E501
+                "You are a SQL expert who generates natural language descriptions of procedures and functions in a PostgreSQL database. "
+                "The descriptions that you generate should be a concise, single sentence."
             ),
         )
 
@@ -644,7 +635,7 @@ async def generate_procedure_descriptions(
             Args:
                 proc_id (int): The ID of the procedure or function (specified in the XML tag)
                 description (str): a concise, single sentence description of the procedure/function
-            """  # noqa: E501
+            """
             nonlocal proc_index
             proc = proc_index.get(proc_id)
             if proc is None:
@@ -795,7 +786,7 @@ async def describe(
 
     Returns:
         Updated Usage object with information about token usage.
-    """  # noqa: E501
+    """
     usage = usage or Usage()
     usage_limits = usage_limits or UsageLimits(request_limit=None)
 
@@ -981,15 +972,15 @@ async def describe(
     table.add_row("Requests", str(usage.requests))
     table.add_row(
         "Request Tokens",
-        str(usage.request_tokens) if usage.request_tokens else "?",  # noqa: E501
+        str(usage.request_tokens) if usage.request_tokens else "?",
     )
     table.add_row(
         "Response Tokens",
-        str(usage.response_tokens) if usage.response_tokens else "?",  # noqa: E501
+        str(usage.response_tokens) if usage.response_tokens else "?",
     )
     table.add_row(
         "Total Tokens",
-        str(usage.total_tokens) if usage.total_tokens else "?",  # noqa: E501
+        str(usage.total_tokens) if usage.total_tokens else "?",
     )
 
     console.print(table)

--- a/projects/pgai/pgai/semantic_catalog/file.py
+++ b/projects/pgai/pgai/semantic_catalog/file.py
@@ -193,7 +193,7 @@ def import_from_yaml(text: TextIO) -> Generator[Item, None, None]:
 
     Raises:
         RuntimeError: If the first document is not a header or has an invalid schema version.
-    """  # noqa: E501
+    """
     for i, doc in enumerate(yaml.safe_load_all(text)):
         if not doc:
             continue
@@ -310,7 +310,7 @@ async def _look_up_proc(
 
     Raises:
         RuntimeError: If the procedure, function, or aggregate is not found in the database.
-    """  # noqa: E501
+    """
     async with target_con.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """\
@@ -493,7 +493,7 @@ async def save_to_catalog(
         target_con: Asynchronous database connection to the target database (where objects are defined).
         catalog_id: ID of the semantic catalog to save to.
         items: Iterator of catalog items to save.
-    """  # noqa: E501
+    """
     for item in items:
         match item.type:
             case "table" | "view":
@@ -570,7 +570,7 @@ async def _load_functions_procedures_aggregates(
 
     Returns:
         An async generator yielding Function, Procedure, and Aggregate objects.
-    """  # noqa: E501
+    """
     await cur.execute(
         SQL("""\
             select
@@ -693,7 +693,7 @@ async def async_export_to_yaml(text: TextIO, items: AsyncIterator[Item]) -> None
     Args:
         text: A text IO stream to write the YAML documents to.
         items: Async iterator of catalog items to export.
-    """  # noqa: E501
+    """
     text.write(Header().to_yaml())
     async for item in items:
         text.write(item.to_yaml())

--- a/projects/pgai/pgai/semantic_catalog/fix.py
+++ b/projects/pgai/pgai/semantic_catalog/fix.py
@@ -211,7 +211,7 @@ def _update_ids_sql(catalog_id: int, obj: _Object, ids: _Ids) -> Composed:
         SQL query to update the object's IDs
     """
     return SQL(
-        "UPDATE ai.{table} SET classid={classid}, objid={objid}, objsubid={objsubid} WHERE id = {id};"  # noqa
+        "UPDATE ai.{table} SET classid={classid}, objid={objid}, objsubid={objsubid} WHERE id = {id};"
     ).format(
         table=Identifier(f"semantic_catalog_obj_{catalog_id}"),
         classid=Literal(ids.classid),
@@ -291,7 +291,7 @@ def _update_names_sql(catalog_id: int, obj: _Object, names: _Names) -> Composed:
         SQL query to update the object's name identifiers
     """
     return SQL(
-        "UPDATE ai.{table} set objtype={objtype}, objnames={objnames}, objargs={objargs} WHERE id = {id};"  # noqa
+        "UPDATE ai.{table} set objtype={objtype}, objnames={objnames}, objargs={objargs} WHERE id = {id};"
     ).format(
         table=Identifier(f"semantic_catalog_obj_{catalog_id}"),
         objtype=Literal(names.objtype),
@@ -390,7 +390,7 @@ async def fix_ids(
         catalog_id: ID of the semantic catalog to fix
         dry_run: If True, only check for issues without making changes
         console: Rich console for output and progress display
-    """  # noqa
+    """
     pbcols = [
         SpinnerColumn(),
         TextColumn("{task.description}"),
@@ -479,7 +479,7 @@ async def fix_names(
         catalog_id: ID of the semantic catalog to fix
         dry_run: If True, only check for issues without making changes
         console: Rich console for output and progress display
-    """  # noqa
+    """
     pbcols = [
         SpinnerColumn(),
         TextColumn("{task.description}"),

--- a/projects/pgai/pgai/semantic_catalog/gen_sql.py
+++ b/projects/pgai/pgai/semantic_catalog/gen_sql.py
@@ -81,7 +81,7 @@ class DatabaseContext:
         rendered_objects: Dictionary mapping object IDs to their rendered text representations.
         rendered_sql_examples: Dictionary mapping SQL example IDs to their rendered text representations.
         rendered_facts: Dictionary mapping fact IDs to their rendered text representations.
-    """  # noqa: E501
+    """
 
     objects: dict[int, Table | View | Procedure]
     sql_examples: dict[int, SQLExample]
@@ -119,7 +119,7 @@ async def fetch_database_context(
 
     Returns:
         A DatabaseContext containing the relevant database objects, SQL examples, and facts.
-    """  # noqa: E501
+    """
     ctx = (
         ctx
         if ctx
@@ -215,7 +215,7 @@ async def fetch_database_context_alt(
 
     Returns:
         A DatabaseContext containing the specified database objects, SQL examples, and facts.
-    """  # noqa: E501
+    """
     ctx = DatabaseContext(
         objects={},
         sql_examples={},
@@ -414,7 +414,7 @@ async def initialize_database_context(
 
     Raises:
         AssertionError: If the context_mode is not one of the supported values.
-    """  # noqa: E501
+    """
     assert context_mode in {"semantic_search", "entire_catalog", "specific_ids"}
     match context_mode:
         case "semantic_search":
@@ -699,7 +699,7 @@ async def generate_sql(
         # Use the generated SQL
         print(response.sql_statement)
         ```
-    """  # noqa: E501
+    """
     usage = usage or Usage()
     usage_limits = usage_limits or UsageLimits(request_limit=None)
     model_settings = model_settings or ModelSettings()

--- a/projects/pgai/pgai/semantic_catalog/loader.py
+++ b/projects/pgai/pgai/semantic_catalog/loader.py
@@ -199,7 +199,7 @@ async def load_tables(
             tables.append(Table.model_validate(row))
         if len(tables) != len(oids):
             logger.warning(
-                f"{len(oids)} oids were provided but only {len(tables)} tables were loaded"  # noqa
+                f"{len(oids)} oids were provided but only {len(tables)} tables were loaded"
             )
         if sample_size > 0:
             logger.debug(
@@ -296,7 +296,7 @@ async def load_views(
             views.append(View.model_validate(row))
         if len(views) != len(oids):
             logger.warning(
-                f"{len(oids)} oids were provided but only {len(views)} views were loaded"  # noqa
+                f"{len(oids)} oids were provided but only {len(views)} views were loaded"
             )
         if sample_size > 0:
             logger.debug(f"sampling {sample_size} rows from each of {len(views)} views")
@@ -446,7 +446,7 @@ async def load_procedures(
             procedures.append(Procedure.model_validate(row))
         if len(procedures) != len(oids):
             logger.warning(
-                f"{len(oids)} oids were provided but only {len(procedures)} procedures were loaded"  # noqa
+                f"{len(oids)} oids were provided but only {len(procedures)} procedures were loaded"
             )
     return procedures
 
@@ -515,7 +515,7 @@ async def load_objects(
 
     Raises:
         ValueError: If an unknown object type is encountered.
-    """  # noqa: E501
+    """
     t: set[int] = set()  # distinct objid
     v: set[int] = set()  # distinct objid
     p: set[int] = set()  # distinct objid

--- a/projects/pgai/pgai/semantic_catalog/models.py
+++ b/projects/pgai/pgai/semantic_catalog/models.py
@@ -97,7 +97,7 @@ class View(BaseModel):
         definition: SQL definition of the view.
         description: Object description containing metadata and textual description.
         sample: Sample data from the view (if available).
-    """  # noqa: E501
+    """
 
     id: int = -1
     classid: int

--- a/projects/pgai/pgai/semantic_catalog/render.py
+++ b/projects/pgai/pgai/semantic_catalog/render.py
@@ -111,7 +111,7 @@ def render_objects(objects: Iterable[Table | View | Procedure]) -> str:
 
     Returns:
         A string containing all rendered objects separated by newlines.
-    """  # noqa: E501
+    """
     return "\n".join(map(render_object, objects)).strip()
 
 

--- a/projects/pgai/pgai/semantic_catalog/sample.py
+++ b/projects/pgai/pgai/semantic_catalog/sample.py
@@ -61,7 +61,7 @@ async def _sample_as_copy_text(
 
     Returns:
         A string containing the COPY command followed by the sampled data in text format.
-    """  # noqa: E501
+    """
     query = SQL(
         "COPY (SELECT * FROM {}.{} LIMIT {}) TO STDOUT WITH (FORMAT TEXT, HEADER true)"
     ).format(

--- a/projects/pgai/pgai/semantic_catalog/search.py
+++ b/projects/pgai/pgai/semantic_catalog/search.py
@@ -89,7 +89,7 @@ async def search_sql_examples(
 
     Returns:
         A list of SQLExample objects ordered by similarity to the query vector.
-    """  # noqa: E501
+    """
     logger.debug(f"searching semantic catalog {catalog_id}")
     params = dict(query=query, limit=limit)
     if exclude_ids:

--- a/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
+++ b/projects/pgai/pgai/semantic_catalog/semantic_catalog.py
@@ -128,7 +128,7 @@ class SemanticCatalog:
 
         Raises:
             RuntimeError: If the embedding could not be added.
-        """  # noqa: E501
+        """
         logger.debug(
             f"adding embedding config {embedding_name} to semantic catalog {self.name}"
         )
@@ -164,7 +164,7 @@ class SemanticCatalog:
             embedding_name: Name of the embedding configuration to drop.
         """
         logger.debug(
-            f"dropping embedding config {embedding_name} from semantic catalog {self.name}"  # noqa
+            f"dropping embedding config {embedding_name} from semantic catalog {self.name}"
         )
         async with con.cursor() as cur:
             await cur.execute(
@@ -256,7 +256,7 @@ class SemanticCatalog:
             batch_size: Number of items to process in each batch.
         """
         logger.debug(
-            f"vectorizing embedding config {embedding_name} in semantic catalog {self.name}"  # noqa
+            f"vectorizing embedding config {embedding_name} in semantic catalog {self.name}"
         )
         await vectorize(con, self.id, embedding_name, config, batch_size)
 
@@ -913,7 +913,7 @@ class SemanticCatalog:
 
         Returns:
             A list of database objects (Tables, Views, Procedures) with metadata and descriptions.
-        """  # noqa: E501
+        """
         return await loader.load_objects(
             catalog_con, target_con, self.id, obj_desc, sample_size
         )
@@ -999,7 +999,7 @@ class SemanticCatalog:
 
         Raises:
             RuntimeError: If no embeddings are configured for the semantic catalog.
-        """  # noqa: E501
+        """
         if embedding_name is None:
             embeddings = await self.list_embeddings(catalog_con)
             if not embeddings:
@@ -1056,7 +1056,7 @@ class SemanticCatalog:
 
         Raises:
             RuntimeError: If the specified embedding configuration is not found.
-        """  # noqa: E501
+        """
         batch_size = batch_size or 32
         console = console or Console(stderr=True, quiet=True)
         console.status("importing yaml file into semantic catalog...")
@@ -1114,7 +1114,7 @@ class SemanticCatalog:
             dry_run: If True, only check for issues without making changes
             console: Rich console for output and progress display. If None, a default
                 console with minimal output is used
-        """  # noqa
+        """
         console = console or Console(stderr=True, quiet=True)
         await fix.fix_ids(catalog_con, target_con, self.id, dry_run, console)
 
@@ -1143,7 +1143,7 @@ class SemanticCatalog:
             dry_run: If True, only check for issues without making changes
             console: Rich console for output and progress display. If None, a default
                 console with minimal output is used
-        """  # noqa
+        """
         console = console or Console(stderr=True, quiet=True)
         await fix.fix_names(catalog_con, target_con, self.id, dry_run, console)
 
@@ -1162,7 +1162,7 @@ async def from_id(con: CatalogConnection, id: int) -> SemanticCatalog:
 
     Raises:
         RuntimeError: If the semantic catalog is not installed or the specified ID is not found.
-    """  # noqa: E501
+    """
     async with con.cursor(row_factory=dict_row) as cur:
         try:
             await cur.execute(
@@ -1198,7 +1198,7 @@ async def from_name(con: CatalogConnection, catalog_name: str) -> SemanticCatalo
 
     Raises:
         RuntimeError: If the semantic catalog is not installed or the specified name is not found.
-    """  # noqa: E501
+    """
     async with con.cursor(row_factory=dict_row) as cur:
         try:
             await cur.execute(
@@ -1276,7 +1276,7 @@ async def create(
 
     Raises:
         RuntimeError: If the semantic catalog could not be created.
-    """  # noqa: E501
+    """
     async with con.cursor(row_factory=dict_row) as cur:
         params: list[Composable] = []
         args: dict[str, Any] = {}

--- a/projects/pgai/pgai/semantic_catalog/vectorizer/__init__.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/__init__.py
@@ -6,7 +6,7 @@ embedding providers including SentenceTransformers, Ollama, and OpenAI.
 
 The vectorizer package is used to generate embeddings for database objects,
 SQL examples, and facts in the semantic catalog, enabling vector similarity search.
-"""  # noqa: E501
+"""
 
 from .vectorizer import (
     EmbeddingConfig,

--- a/projects/pgai/pgai/semantic_catalog/vectorizer/ollama.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/ollama.py
@@ -29,7 +29,7 @@ async def embed_batch(config: OllamaConfig, batch: list[EmbedRow]) -> None:
     response = await client.embed(config.model, [x.content for x in batch])
     if len(response.embeddings) != len(batch):
         raise RuntimeError(
-            f"{len(batch)} items sent to ollama but {len(response.embeddings)} embeddings returned"  # noqa
+            f"{len(batch)} items sent to ollama but {len(response.embeddings)} embeddings returned"
         )
     for i, embed in enumerate(response.embeddings):
         batch[i].vector = embed

--- a/projects/pgai/pgai/semantic_catalog/vectorizer/openai.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/openai.py
@@ -37,7 +37,7 @@ async def embed_batch(config: OpenAIConfig, batch: list[EmbedRow]) -> None:
     )
     if len(response.data) != len(batch):
         raise RuntimeError(
-            f"{len(batch)} items sent to openai but {len(response.data)} embeddings returned"  # noqa
+            f"{len(batch)} items sent to openai but {len(response.data)} embeddings returned"
         )
     for emb in response.data:
         batch[emb.index].vector = emb.embedding

--- a/projects/pgai/pgai/semantic_catalog/vectorizer/sentence_tranformers.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/sentence_tranformers.py
@@ -51,7 +51,7 @@ async def embed_batch(
 
     Raises:
         AssertionError: If the number of embeddings returned doesn't match the batch size.
-    """  # noqa: E501
+    """
     st = SentenceTransformer(
         config.model, trust_remote_code=True
     )  # TODO: configurable?

--- a/projects/pgai/pgai/semantic_catalog/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/semantic_catalog/vectorizer/vectorizer.py
@@ -6,7 +6,7 @@ content to be vectorized, and functions for processing and saving embeddings.
 
 The vectorizer supports multiple embedding providers (SentenceTransformers, Ollama, OpenAI)
 and can vectorize different types of content (database objects, SQL examples, facts).
-"""  # noqa: E501
+"""
 
 import logging
 from collections.abc import Sequence
@@ -140,7 +140,7 @@ class OpenAIConfig(BaseModel):
 
         Returns:
             A new OpenAIConfig instance.
-        """  # noqa: E501
+        """
         return cls(
             implementation="openai",
             config_type="embedding",
@@ -234,7 +234,7 @@ async def _get_obj_batch(
         )
         batch = [EmbedRow(**row) for row in await cur.fetchall()]
         logger.debug(
-            f"got batch of {len(batch)} objects for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+            f"got batch of {len(batch)} objects for {embedding_name} of semantic catalog {catalog_id}"
         )
         return batch
 
@@ -279,7 +279,7 @@ async def _get_sql_batch(
         )
         batch = [EmbedRow(**row) for row in await cur.fetchall()]
         logger.debug(
-            f"got batch of {len(batch)} sql examples for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+            f"got batch of {len(batch)} sql examples for {embedding_name} of semantic catalog {catalog_id}"
         )
         return batch
 
@@ -320,7 +320,7 @@ async def _get_fact_batch(
         )
         batch = [EmbedRow(**row) for row in await cur.fetchall()]
         logger.debug(
-            f"got batch of {len(batch)} facts for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+            f"got batch of {len(batch)} facts for {embedding_name} of semantic catalog {catalog_id}"
         )
         return batch
 
@@ -387,7 +387,7 @@ async def _save_batch(
     assert table in {"obj", "sql", "fact"}
     async with con.cursor() as cur:
         logger.debug(
-            f"saving batch of {len(batch)} vectors for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+            f"saving batch of {len(batch)} vectors for {embedding_name} of semantic catalog {catalog_id}"
         )
         for row in batch:
             await cur.execute(
@@ -433,11 +433,11 @@ async def vectorize(
                 )
                 if not batch:
                     logger.debug(
-                        f"no items found to vectorize for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+                        f"no items found to vectorize for {embedding_name} of semantic catalog {catalog_id}"
                     )
                     break
                 logger.debug(
-                    f"vectorizing {len(batch)} items for {embedding_name} of semantic catalog {catalog_id}"  # noqa
+                    f"vectorizing {len(batch)} items for {embedding_name} of semantic catalog {catalog_id}"
                 )
                 match config:
                     case SentenceTransformersConfig():
@@ -471,7 +471,7 @@ async def vectorize_query(config: EmbeddingConfig, query: str) -> Sequence[float
 
     Raises:
         ValueError: If the embedding provider configuration is unrecognized.
-    """  # noqa: E501
+    """
     match config:
         case SentenceTransformersConfig():
             from .sentence_tranformers import embed_query

--- a/projects/pgai/pgai/vectorizer/embedders/litellm.py
+++ b/projects/pgai/pgai/vectorizer/embedders/litellm.py
@@ -70,18 +70,18 @@ class LiteLLM(ApiKeyMixin, BaseModel, Embedder):
             case "azure":
                 return 2048  # https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/embeddings?tabs=console#verify-inputs-dont-exceed-the-maximum-length
             case "bedrock":
-                return 96  # NOTE: currently (Jan 2025) Bedrock only supports embeddings with Cohere or Titan models. The Titan API only processes one input per request, which LiteLLM already handles under the hood. We assume that the Cohere API has the same input limits as above.  # noqa
+                return 96  # NOTE: currently (Jan 2025) Bedrock only supports embeddings with Cohere or Titan models. The Titan API only processes one input per request, which LiteLLM already handles under the hood. We assume that the Cohere API has the same input limits as above.
             case "huggingface":
-                return 2048  # NOTE: There is not documented limit. In testing we got a response for a request with 10k (short) inputs.  # noqa
+                return 2048  # NOTE: There is not documented limit. In testing we got a response for a request with 10k (short) inputs.
             case "mistral":
                 return 128  # NOTE: this is chosen somewhat arbitrarily.
             case "vertex_ai":
-                return 250  # FIXME: this applies to `us-central-1` only (otherwise 5). See https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#get_text_embeddings_for_a_snippet_of_text  # noqa
+                return 250  # FIXME: this applies to `us-central-1` only (otherwise 5). See https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#get_text_embeddings_for_a_snippet_of_text
             case "voyage":
                 return 128  # see https://docs.voyageai.com/reference/embeddings-api
             case _:
                 logger.warn(
-                    f"unknown provider '{custom_llm_provider}', falling back to conservative max chunks per batch"  # noqa: E501
+                    f"unknown provider '{custom_llm_provider}', falling back to conservative max chunks per batch"
                 )
                 return 5
 
@@ -95,7 +95,7 @@ class LiteLLM(ApiKeyMixin, BaseModel, Embedder):
             case "mistral":
                 return 16_000  # No official documentation, see: https://github.com/langchain-ai/langchain/blob/33354f984fba660e71ca0039cfbd3cf37643cfab/libs/partners/mistralai/langchain_mistralai/embeddings.py#L25
             case "vertex_ai":
-                return 20_000  # See https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#get_text_embeddings_for_a_snippet_of_text  # noqa
+                return 20_000  # See https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#get_text_embeddings_for_a_snippet_of_text
             case "openai" | "azure":
                 return 600_000
             case "voyage":

--- a/projects/pgai/pgai/vectorizer/embedders/openai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/openai.py
@@ -188,10 +188,10 @@ class OpenAI(ApiKeyMixin, BaseURLMixin, BaseModel, Embedder):
                 tokenized_length = len(tokenized)
                 if tokenized_length > context_length:
                     await logger.awarning(
-                        f"chunk truncated from {len(tokenized)} to {context_length} tokens"  # noqa
+                        f"chunk truncated from {len(tokenized)} to {context_length} tokens"
                     )
                     documents[i] = encoder.decode(tokenized[:context_length])
-        # OpenAIs per batch token limit is using a token estimator instead of actual tokens  # noqa: E501
+        # OpenAIs per batch token limit is using a token estimator instead of actual tokens
         # So we are reproducing their token counts
         token_counts = [self._estimate_token_length(document) for document in documents]
         async for embeddings in self.batch_chunks_and_embed(documents, token_counts):

--- a/projects/pgai/pgai/vectorizer/embedders/voyageai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/voyageai.py
@@ -20,14 +20,14 @@ def voyage_max_tokens_per_batch(model: str) -> int:
     # The total number of tokens in the list is at most:
     # - 1M for voyage-3-lite
     # - 320K for voyage-3 and voyage-2
-    # - 120K for voyage-3-large, voyage-code-3, voyage-large-2-instruct, voyage-finance-2, voyage-multilingual-2, voyage-law-2, and voyage-large-2  # noqa
+    # - 120K for voyage-3-large, voyage-code-3, voyage-large-2-instruct, voyage-finance-2, voyage-multilingual-2, voyage-law-2, and voyage-large-2
     match model:
         case "voyage-3-lite":
             return 1_000_000
         case "voyage-2" | "voyage-3":
             return 320_000
         case _:
-            return 120_000  # NOTE: This is conservative, but there probably won't be new Voyage models, so...  # noqa
+            return 120_000  # NOTE: This is conservative, but there probably won't be new Voyage models, so...
 
 
 def voyage_token_counter(model: str) -> Callable[[str], int] | None:

--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -49,7 +49,7 @@ def batch_indices(
     for idx, chunk_tokens in enumerate(chunk_token_lengths):
         if max_tokens_per_batch is not None and chunk_tokens > max_tokens_per_batch:
             raise BatchingError(
-                f"chunk length {chunk_tokens} greater than max_tokens_per_batch {max_tokens_per_batch}"  # noqa
+                f"chunk length {chunk_tokens} greater than max_tokens_per_batch {max_tokens_per_batch}"
             )
         max_tokens_reached = (
             max_tokens_per_batch is not None
@@ -58,7 +58,7 @@ def batch_indices(
         max_chunks_reached = len(batch) + 1 > max_chunks_per_batch
         if max_tokens_reached or max_chunks_reached:
             logger.debug(
-                f"Batch {len(batches) + 1} has {token_count} tokens in {len(batch)} chunks"  # noqa
+                f"Batch {len(batches) + 1} has {token_count} tokens in {len(batch)} chunks"
             )
             batches.append(batch)
             batch = []

--- a/projects/pgai/pgai/vectorizer/formatting.py
+++ b/projects/pgai/pgai/vectorizer/formatting.py
@@ -32,7 +32,7 @@ class ChunkValue(BaseModel, Formatter):
     implementation: Literal["chunk_value"]
 
     @override
-    def format(self, chunk: str, item: dict[str, Any]) -> str:  # noqa
+    def format(self, chunk: str, item: dict[str, Any]) -> str:
         """
         Returns the chunk of text without any formatting.
 

--- a/projects/pgai/pgai/vectorizer/generate/config_generator.py
+++ b/projects/pgai/pgai/vectorizer/generate/config_generator.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 from pathlib import Path
 
 from jinja2 import Environment

--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -817,7 +817,7 @@ class Executor:
                             e.msg,
                             Jsonb(
                                 {
-                                    "provider": self.vectorizer.config.embedding.implementation,  # noqa
+                                    "provider": self.vectorizer.config.embedding.implementation,
                                     "error_reason": str(e.__cause__),
                                 }
                             ),
@@ -825,7 +825,7 @@ class Executor:
                     )
 
                 if e.__cause__ is not None:
-                    raise e.__cause__  # noqa
+                    raise e.__cause__  # noqa: B904
                 raise e
 
             except Exception as e:

--- a/projects/pgai/pgai/vectorizer/worker.py
+++ b/projects/pgai/pgai/vectorizer/worker.py
@@ -55,7 +55,7 @@ def warn_on_old_version(version: Version):
             version.pgai_lib_version
         ):
             logger.warning(
-                f"The pgai installation in your database is outdated and can be upgraded. Installed version: {version.pgai_lib_version}, latest version: {__version__}."  # noqa
+                f"The pgai installation in your database is outdated and can be upgraded. Installed version: {version.pgai_lib_version}, latest version: {__version__}."
             )
 
 
@@ -115,7 +115,7 @@ class Worker:
             con.cursor(row_factory=dict_row) as cur,
         ):
             cur.execute(
-                "select pg_catalog.to_jsonb(v) as vectorizer from ai.vectorizer v where v.id = %s",  # noqa
+                "select pg_catalog.to_jsonb(v) as vectorizer from ai.vectorizer v where v.id = %s",
                 (vectorizer_id,),
             )
             row = cur.fetchone()
@@ -150,7 +150,7 @@ class Worker:
                     vectorizer.config.embedding.set_api_key(secrets)
                 else:
                     logger.error(
-                        f"cannot set secret value '{api_key_name}' for vectorizer with id: '{vectorizer.id}'"  # noqa
+                        f"cannot set secret value '{api_key_name}' for vectorizer with id: '{vectorizer.id}'"
                     )
             return vectorizer
 
@@ -245,7 +245,7 @@ class Worker:
                             self.vectorizer_ids,
                         )
                         if len(valid_vectorizer_ids) != len(self.vectorizer_ids):
-                            err_msg = f"invalid vectorizers, wanted: {list(self.vectorizer_ids)}, got: {valid_vectorizer_ids}"  # noqa: E501
+                            err_msg = f"invalid vectorizers, wanted: {list(self.vectorizer_ids)}, got: {valid_vectorizer_ids}"
                             exception = await self._handle_error(
                                 err_msg,
                                 None,
@@ -264,7 +264,7 @@ class Worker:
                         try:
                             vectorizer = self._get_vectorizer(vectorizer_id, features)
                         except (VectorizerNotFoundError, ApiKeyNotFoundError) as e:
-                            err_msg = f"error getting vectorizer: {type(e).__name__}: {str(e)}"  # noqa: E501
+                            err_msg = f"error getting vectorizer: {type(e).__name__}: {str(e)}"
                             exception = await self._handle_error(
                                 err_msg, vectorizer_id, worker_tracking
                             )

--- a/projects/pgai/pgai/vectorizer/worker_tracking/worker_tracking.py
+++ b/projects/pgai/pgai/vectorizer/worker_tracking/worker_tracking.py
@@ -67,7 +67,7 @@ class WorkerTracking:
         async with await psycopg.AsyncConnection.connect(
             self.db_url,
             autocommit=True,
-            application_name=f"pgai-worker-heartbeat-force: {self.get_short_worker_id()}",  # noqa: E501
+            application_name=f"pgai-worker-heartbeat-force: {self.get_short_worker_id()}",
         ) as conn:
             await self._heartbeat(conn)
 
@@ -101,7 +101,7 @@ class WorkerTracking:
                 async with await psycopg.AsyncConnection.connect(
                     self.db_url,
                     autocommit=True,
-                    application_name=f"pgai-worker-heartbeat: {self.get_short_worker_id()}",  # noqa: E501
+                    application_name=f"pgai-worker-heartbeat: {self.get_short_worker_id()}",
                 ) as conn:
                     while True:
                         await self._heartbeat(conn)
@@ -145,7 +145,7 @@ class WorkerTracking:
             await psycopg.AsyncConnection.connect(
                 self.db_url,
                 autocommit=True,
-                application_name=f"pgai-worker-error-reporter: {self.get_short_worker_id()}",  # noqa: E501
+                application_name=f"pgai-worker-error-reporter: {self.get_short_worker_id()}",
             ) as conn,
             conn.cursor() as cur,
             conn.transaction(),

--- a/projects/pgai/pyproject.toml
+++ b/projects/pgai/pyproject.toml
@@ -128,6 +128,7 @@ select = [
     "PIE",  # print statements
     "Q"     # flakes8-quote
 ]
+ignore = ["E501"] # we use `ruff format` on everything, so this is just annoying
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
We use `ruff format` to format all python files, so cases where we exceed the configured max line length are rare, and usually to do with formatting/outputting strings. The nag of E501 is a waste of time.