### PR TITLE
fix: store ModelRequest in generate_sql messages list

### DIFF
--- a/projects/pgai/pgai/cli.py
+++ b/projects/pgai/pgai/cli.py
@@ -1347,7 +1347,10 @@ def generate_sql(
     console.print(Syntax(resp.sql_statement, "sql", word_wrap=True))
 
     if save_final_prompt:
-        save_final_prompt.expanduser().resolve().write_text(resp.final_prompt)
+        # The final prompt is the user prompt of the last message request we made.
+        save_final_prompt.expanduser().resolve().write_text(
+            str(resp.messages[-1][0].parts[-1].content)
+        )
 
 
 @semantic_catalog.command()


### PR DESCRIPTION
PR modifies the `GenerateSQLResponse.messages` value such that it's now a `list[tuple[ModelRequest, ModelResponse]]`, so that we capture both the request to the model as well as its response, where previously we were just capturing the response. This should make introspection of the generate process easier.

As part of this, I removed the `GenerateSQLResponse.final_prompt` value as this is just a duplicate of the final `ModelRequest` object that we have in the messages list.