### PR TITLE
Treat oid's as bigint

### DIFF
--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -359,8 +359,8 @@ class VectorizerQueryBuilder:
                     SELECT
                         {pk_fields},
                         pg_try_advisory_xact_lock(
-                            %s,
-                            hashtext(concat_ws('|', {lock_fields}))
+                            %s::oid::bigint,
+                            hashtext(concat_ws('|', {lock_fields}))::bigint
                         ) AS locked
                     FROM (
                         SELECT DISTINCT {pk_fields}
@@ -468,8 +468,8 @@ class VectorizerQueryBuilder:
                     SELECT
                         {pk_fields}, {loading_retries},
                         pg_try_advisory_xact_lock(
-                            %s,
-                            hashtext(concat_ws('|', {lock_fields}))
+                            %s::oid::bigint,
+                            hashtext(concat_ws('|', {lock_fields}))::bigint
                         ) AS locked
                     FROM (
                         SELECT DISTINCT {pk_fields}, {loading_retries}


### PR DESCRIPTION
oids are 4 byte unsigned integers, and oids > 2^31 will cause errors when these functions are called.

Oids > 2^31 are a regular occurence in PostgreSQL, especially when temporary tables are used, or a lot of chunks/partitions are created and dropped.