### PR TITLE
fix: prevent HTTP client connection leaks in embedders

### DIFF
--- a/projects/pgai/pgai/vectorizer/embedders/ollama.py
+++ b/projects/pgai/pgai/vectorizer/embedders/ollama.py
@@ -70,6 +70,24 @@ class Ollama(BaseModel, BaseURLMixin, Embedder):
     model: str
     options: OllamaOptions | None = None
     keep_alive: str | None = None  # this is only `str` because of the SQL API
+    _client: "ollama.AsyncClient | None" = None
+
+    def _get_client(self) -> "ollama.AsyncClient":
+        # Note: deferred import to avoid import overhead
+        import ollama
+
+        if self._client is None:
+            self._client = ollama.AsyncClient(host=self.base_url)
+        return self._client
+
+    @override
+    async def cleanup(self) -> None:
+        """Close the underlying HTTP client to prevent connection leaks."""
+        if self._client is not None:
+            # Ollama's AsyncClient uses httpx internally
+            if hasattr(self._client, "_client") and self._client._client is not None:
+                await self._client._client.aclose()
+            self._client = None
 
     @override
     async def embed(
@@ -101,7 +119,7 @@ class Ollama(BaseModel, BaseURLMixin, Embedder):
         # Note: deferred import to avoid import overhead
         import ollama
 
-        client = ollama.AsyncClient(host=self.base_url)
+        client = self._get_client()
         try:
             await client.show(self.model)
         except ollama.ResponseError as e:
@@ -113,10 +131,7 @@ class Ollama(BaseModel, BaseURLMixin, Embedder):
 
     @override
     async def call_embed_api(self, documents: list[str]) -> EmbeddingResponse:
-        # Note: deferred import to avoid import overhead
-        import ollama
-
-        response = await ollama.AsyncClient(host=self.base_url).embed(
+        response = await self._get_client().embed(
             model=self.model,
             input=documents,
             options=self.options,
@@ -132,10 +147,7 @@ class Ollama(BaseModel, BaseURLMixin, Embedder):
         """
         Gets the context_length of the configured model, if available
         """
-        # Note: deferred import to avoid import overhead
-        import ollama
-
-        model = await ollama.AsyncClient(host=self.base_url).show(self.model)
+        model = await self._get_client().show(self.model)
         architecture = model["model_info"].get("general.architecture", None)
         if architecture is None:
             logger.warn(f"unable to determine architecture for model '{self.model}'")

--- a/projects/pgai/pgai/vectorizer/embedders/openai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/openai.py
@@ -90,13 +90,24 @@ class OpenAI(ApiKeyMixin, BaseURLMixin, BaseModel, Embedder):
 
         return self.user if self.user is not None else openai.NOT_GIVEN
 
-    @cached_property
+    _client: "openai.AsyncOpenAI | None" = None
+
+    @property
     def _embedder(self) -> "resources.AsyncEmbeddingsWithStreamingResponse":
         import openai
 
-        return openai.AsyncOpenAI(
-            base_url=self.base_url, api_key=self._api_key, max_retries=3
-        ).embeddings.with_streaming_response
+        if self._client is None:
+            self._client = openai.AsyncOpenAI(
+                base_url=self.base_url, api_key=self._api_key, max_retries=3
+            )
+        return self._client.embeddings.with_streaming_response
+
+    @override
+    async def cleanup(self) -> None:
+        """Close the underlying HTTP client to prevent connection leaks."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
 
     @override
     def _max_chunks_per_batch(self) -> int:

--- a/projects/pgai/pgai/vectorizer/embedders/voyageai.py
+++ b/projects/pgai/pgai/vectorizer/embedders/voyageai.py
@@ -70,6 +70,24 @@ class VoyageAI(ApiKeyMixin, BaseModel, Embedder):
     input_type: Literal["document"] | Literal["query"] | None = None
     output_dimension: int | None = None
     output_dtype: str | None = None
+    _client: "voyageai.AsyncClient | None" = None
+
+    def _get_client(self) -> "voyageai.AsyncClient":
+        # Note: deferred import to avoid import overhead
+        import voyageai
+
+        if self._client is None:
+            self._client = voyageai.AsyncClient(api_key=self._api_key)
+        return self._client
+
+    @override
+    async def cleanup(self) -> None:
+        """Close the underlying HTTP client to prevent connection leaks."""
+        if self._client is not None:
+            # VoyageAI's AsyncClient uses httpx internally
+            if hasattr(self._client, "_client") and self._client._client is not None:
+                await self._client._client.aclose()
+            self._client = None
 
     @override
     async def embed(
@@ -107,9 +125,6 @@ class VoyageAI(ApiKeyMixin, BaseModel, Embedder):
 
     @override
     async def call_embed_api(self, documents: list[str]) -> EmbeddingResponse:
-        # Note: deferred import to avoid import overhead
-        import voyageai
-
         # Build API call parameters
         params: dict[str, Any] = {
             "model": self.model,
@@ -120,7 +135,7 @@ class VoyageAI(ApiKeyMixin, BaseModel, Embedder):
         if self.output_dtype is not None:
             params["output_dtype"] = self.output_dtype
 
-        response = await voyageai.AsyncClient(api_key=self._api_key).embed(
+        response = await self._get_client().embed(
             documents,
             **params,
         )

--- a/projects/pgai/pgai/vectorizer/embeddings.py
+++ b/projects/pgai/pgai/vectorizer/embeddings.py
@@ -118,6 +118,12 @@ class Embedder(ABC):
         Setup the embedder
         """
 
+    async def cleanup(self) -> None:  # noqa: B027 empty on purpose
+        """
+        Cleanup resources used by the embedder (e.g., close HTTP clients).
+        Should be called when the embedder is no longer needed.
+        """
+
     @abstractmethod
     async def call_embed_api(self, documents: list[str]) -> EmbeddingResponse:
         """

--- a/projects/pgai/pgai/vectorizer/vectorizer.py
+++ b/projects/pgai/pgai/vectorizer/vectorizer.py
@@ -839,6 +839,10 @@ class Executor:
                         ),
                     )
                 raise e
+            finally:
+                # Clean up embedder resources (e.g., close HTTP clients)
+                # to prevent connection leaks
+                await self.vectorizer.config.embedding.cleanup()
 
     async def _should_continue_processing(
         self, conn: AsyncConnection, loops: int, res: int


### PR DESCRIPTION
Fixes #919

## Problem

The AsyncOpenAI, Ollama, and VoyageAI embedders create HTTP clients that are never explicitly closed. This causes connections to accumulate in CLOSE_WAIT state and eventually exhaust file descriptors.

### Investigation Details

In production, we observed:
- ~35,000 file descriptors held by `pgai-vectorizer-worker`
- All were sockets in CLOSE_WAIT state
- Connections were to the OpenAI API (via Cloudflare)
- The `systemd` error: `Failed to allocate manager object: Too many open files`

### Root Cause

The `_embedder` property in `openai.py` creates an `AsyncOpenAI` client that holds an `httpx.AsyncClient`. When the embedder is garbage collected, the HTTP client's connections are not properly closed, leaving them in CLOSE_WAIT until the OS times them out.

Similar patterns exist in `ollama.py` and `voyageai.py`.

## Solution

1. Add `cleanup()` method to the `Embedder` base class
2. Implement `cleanup()` in OpenAI, Ollama, and VoyageAI embedders to close underlying HTTP clients
3. Call `cleanup()` in `Executor.run()`'s finally block to ensure resources are released
4. Reuse client instances instead of creating new ones for each request (Ollama, VoyageAI)

## Changes

- `embeddings.py`: Add `cleanup()` method to base class
- `openai.py`: Store client reference, implement `cleanup()`
- `ollama.py`: Add `_get_client()` for client reuse, implement `cleanup()`
- `voyageai.py`: Add `_get_client()` for client reuse, implement `cleanup()`
- `vectorizer.py`: Call `cleanup()` in finally block

## Testing

This fix was developed in response to a production issue. We recommend:
- Unit tests for `cleanup()` methods
- Integration test that verifies no file descriptor leak after multiple embedding batches